### PR TITLE
Add `db_charset` to fix postgresql installation error.

### DIFF
--- a/app/Http/Controllers/Install/Database.php
+++ b/app/Http/Controllers/Install/Database.php
@@ -63,6 +63,7 @@ class Database extends Controller
             'password'  => $request['password'],
             'driver'    => env('DB_CONNECTION', 'mysql'),
             'port'      => env('DB_PORT', '3306'),
+            'charset'   => env('DB_CHARSET', 'utf8mb4'),
         ]);
 
         try {


### PR DESCRIPTION
Need to set `db_charset` and use it for installation connection to contest `missing index: 'charset'` error. Also need to add `DB_CHARSET` to `.env` file. 

Error happens on postgresql 10 (and probably previous versions).