### PR TITLE
fix overlapping content

### DIFF
--- a/resources/views/expenses/bills/show.blade.php
+++ b/resources/views/expenses/bills/show.blade.php
@@ -170,89 +170,91 @@
         </div>
     </div>
 
-    <div class="col-xs-6 no-padding-left">
-        <div class="box box-default collapsed-box">
-            <div class="box-header with-border">
-                <h3 class="box-title">{{ trans('bills.histories') }}</h3>
+    <div class="row">
+        <div class="col-xs-6">
+            <div class="box box-default collapsed-box">
+                <div class="box-header with-border">
+                    <h3 class="box-title">{{ trans('bills.histories') }}</h3>
 
-                <div class="box-tools pull-right">
-                    <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                    <div class="box-tools pull-right">
+                        <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                    </div>
+                    <!-- /.box-tools -->
                 </div>
-                <!-- /.box-tools -->
-            </div>
-            <div class="box-body">
-                <div class="table-responsive">
-                    <table class="table">
-                        <thead>
-                        <tr>
-                            <th>{{ trans('general.date') }}</th>
-                            <th>{{ trans_choice('general.statuses', 1) }}</th>
-                            <th>{{ trans('general.description') }}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @foreach($bill->histories as $history)
+                <div class="box-body">
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
                             <tr>
-                                <td>{{ Date::parse($bill->created_at)->format($date_format) }}</td>
-                                <td>{{ $bill->status->name }}</td>
-                                <td>{{ $bill->description }}</td>
+                                <th>{{ trans('general.date') }}</th>
+                                <th>{{ trans_choice('general.statuses', 1) }}</th>
+                                <th>{{ trans('general.description') }}</th>
                             </tr>
-                        @endforeach
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                            @foreach($bill->histories as $history)
+                                <tr>
+                                    <td>{{ Date::parse($bill->created_at)->format($date_format) }}</td>
+                                    <td>{{ $bill->status->name }}</td>
+                                    <td>{{ $bill->description }}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <div class="col-xs-6 no-padding-right">
-        <div class="box box-default collapsed-box">
-            <div class="box-header with-border">
-                <h3 class="box-title">{{ trans('bills.payments') }}</h3>
+        <div class="col-xs-6">
+            <div class="box box-default collapsed-box">
+                <div class="box-header with-border">
+                    <h3 class="box-title">{{ trans('bills.payments') }}</h3>
 
-                <div class="box-tools pull-right">
-                    <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                    <div class="box-tools pull-right">
+                        <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                    </div>
+                    <!-- /.box-tools -->
                 </div>
-                <!-- /.box-tools -->
-            </div>
-            <div class="box-body">
-                <div class="table-responsive">
-                    <table class="table">
-                        <thead>
-                        <tr>
-                            <th>{{ trans('general.date') }}</th>
-                            <th>{{ trans('general.amount') }}</th>
-                            <th>{{ trans_choice('general.accounts', 1) }}</th>
-                            <th style="width: 15%;">{{ trans('general.actions') }}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @foreach($bill->payments as $payment)
+                <div class="box-body">
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
                             <tr>
-                                <td>{{ Date::parse($payment->paid_at)->format($date_format) }}</td>
-                                <td>@money($payment->amount, $payment->currency_code, true)</td>
-                                <td>{{ $payment->account->name }}</td>
-                                <td>
-                                    <a href="{{ url('expenses/bills/' . $payment->id) }}" class="btn btn-info btn-xs hidden"><i class="fa fa-eye" aria-hidden="true"></i> {{ trans('general.show') }}</a>
-                                    <a href="{{ url('expenses/bills/' . $payment->id . '/edit') }}" class="btn btn-primary btn-xs  hidden"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{ trans('general.edit') }}</a>
-                                    {!! Form::open([
-                                        'id' => 'bill-payment-' . $payment->id,
-                                        'method' => 'DELETE',
-                                        'url' => ['expenses/bills/payment', $payment->id],
-                                        'style' => 'display:inline'
-                                    ]) !!}
-                                    {!! Form::button('<i class="fa fa-trash-o" aria-hidden="true"></i> ' . trans('general.delete'), array(
-                                        'type'    => 'button',
-                                        'class'   => 'btn btn-danger btn-xs',
-                                        'title'   => trans('general.delete'),
-                                        'onclick' => 'confirmDelete("' . '#bill-payment-' . $payment->id . '", "' . trans_choice('general.payments', 2) . '", "' . trans('general.delete_confirm', ['name' => '<strong>' . Date::parse($payment->paid_at)->format($date_format) . ' - ' . money($payment->amount, $payment->currency_code, true) . ' - ' . $payment->account->name . '</strong>', 'type' => strtolower(trans_choice('general.revenues', 1))]) . '", "' . trans('general.cancel') . '", "' . trans('general.delete') . '")'
-                                    )) !!}
-                                    {!! Form::close() !!}
-                                </td>
+                                <th>{{ trans('general.date') }}</th>
+                                <th>{{ trans('general.amount') }}</th>
+                                <th>{{ trans_choice('general.accounts', 1) }}</th>
+                                <th style="width: 15%;">{{ trans('general.actions') }}</th>
                             </tr>
-                        @endforeach
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                            @foreach($bill->payments as $payment)
+                                <tr>
+                                    <td>{{ Date::parse($payment->paid_at)->format($date_format) }}</td>
+                                    <td>@money($payment->amount, $payment->currency_code, true)</td>
+                                    <td>{{ $payment->account->name }}</td>
+                                    <td>
+                                        <a href="{{ url('expenses/bills/' . $payment->id) }}" class="btn btn-info btn-xs hidden"><i class="fa fa-eye" aria-hidden="true"></i> {{ trans('general.show') }}</a>
+                                        <a href="{{ url('expenses/bills/' . $payment->id . '/edit') }}" class="btn btn-primary btn-xs  hidden"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{ trans('general.edit') }}</a>
+                                        {!! Form::open([
+                                            'id' => 'bill-payment-' . $payment->id,
+                                            'method' => 'DELETE',
+                                            'url' => ['expenses/bills/payment', $payment->id],
+                                            'style' => 'display:inline'
+                                        ]) !!}
+                                        {!! Form::button('<i class="fa fa-trash-o" aria-hidden="true"></i> ' . trans('general.delete'), array(
+                                            'type'    => 'button',
+                                            'class'   => 'btn btn-danger btn-xs',
+                                            'title'   => trans('general.delete'),
+                                            'onclick' => 'confirmDelete("' . '#bill-payment-' . $payment->id . '", "' . trans_choice('general.payments', 2) . '", "' . trans('general.delete_confirm', ['name' => '<strong>' . Date::parse($payment->paid_at)->format($date_format) . ' - ' . money($payment->amount, $payment->currency_code, true) . ' - ' . $payment->account->name . '</strong>', 'type' => strtolower(trans_choice('general.revenues', 1))]) . '", "' . trans('general.cancel') . '", "' . trans('general.delete') . '")'
+                                        )) !!}
+                                        {!! Form::close() !!}
+                                    </td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/incomes/invoices/show.blade.php
+++ b/resources/views/incomes/invoices/show.blade.php
@@ -175,89 +175,91 @@
         </section>
     </div>
 
-    <div class="col-xs-6 no-padding-left">
-        <div class="box box-default collapsed-box">
-            <div class="box-header with-border">
-                <h3 class="box-title">{{ trans('invoices.histories') }}</h3>
+    <div class="row">
+        <div class="col-xs-6">
+            <div class="box box-default collapsed-box">
+                <div class="box-header with-border">
+                    <h3 class="box-title">{{ trans('invoices.histories') }}</h3>
 
-                <div class="box-tools pull-right">
-                    <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                    <div class="box-tools pull-right">
+                        <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                    </div>
+                    <!-- /.box-tools -->
                 </div>
-                <!-- /.box-tools -->
-            </div>
-            <div class="box-body">
-                <div class="table-responsive">
-                    <table class="table">
-                        <thead>
-                        <tr>
-                            <th>{{ trans('general.date') }}</th>
-                            <th>{{ trans_choice('general.statuses', 1) }}</th>
-                            <th>{{ trans('general.description') }}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @foreach($invoice->histories as $history)
+                <div class="box-body">
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
                             <tr>
-                                <td>{{ Date::parse($history->created_at)->format($date_format) }}</td>
-                                <td>{{ $history->status->name }}</td>
-                                <td>{{ $history->description }}</td>
+                                <th>{{ trans('general.date') }}</th>
+                                <th>{{ trans_choice('general.statuses', 1) }}</th>
+                                <th>{{ trans('general.description') }}</th>
                             </tr>
-                        @endforeach
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                            @foreach($invoice->histories as $history)
+                                <tr>
+                                    <td>{{ Date::parse($history->created_at)->format($date_format) }}</td>
+                                    <td>{{ $history->status->name }}</td>
+                                    <td>{{ $history->description }}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <div class="col-xs-6 no-padding-right">
-        <div class="box box-default collapsed-box">
-            <div class="box-header with-border">
-                <h3 class="box-title">{{ trans('invoices.payments') }}</h3>
+        <div class="col-xs-6">
+            <div class="box box-default collapsed-box">
+                <div class="box-header with-border">
+                    <h3 class="box-title">{{ trans('invoices.payments') }}</h3>
 
-                <div class="box-tools pull-right">
-                    <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                    <div class="box-tools pull-right">
+                        <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                    </div>
+                    <!-- /.box-tools -->
                 </div>
-                <!-- /.box-tools -->
-            </div>
-            <div class="box-body">
-                <div class="table-responsive">
-                    <table class="table">
-                        <thead>
-                        <tr>
-                            <th>{{ trans('general.date') }}</th>
-                            <th>{{ trans('general.amount') }}</th>
-                            <th>{{ trans_choice('general.accounts', 1) }}</th>
-                            <th style="width: 15%;">{{ trans('general.actions') }}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @foreach($invoice->payments as $payment)
+                <div class="box-body">
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
                             <tr>
-                                <td>{{ Date::parse($payment->paid_at)->format($date_format) }}</td>
-                                <td>@money($payment->amount, $payment->currency_code, true)</td>
-                                <td>{{ $payment->account->name }}</td>
-                                <td>
-                                    <a href="{{ url('incomes/invoices/' . $payment->id . '') }}" class="btn btn-info btn-xs hidden"><i class="fa fa-eye" aria-hidden="true"></i> {{ trans('general.show') }}</a>
-                                    <a href="{{ url('incomes/revenues/' . $payment->id . '/edit') }}" class="btn btn-primary btn-xs  hidden"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{ trans('general.edit') }}</a>
-                                    {!! Form::open([
-                                        'id' => 'invoice-payment-' . $payment->id,
-                                        'method' => 'DELETE',
-                                        'url' => ['incomes/invoices/payment', $payment->id],
-                                        'style' => 'display:inline'
-                                    ]) !!}
-                                    {!! Form::button('<i class="fa fa-trash-o" aria-hidden="true"></i> ' . trans('general.delete'), array(
-                                        'type'    => 'button',
-                                        'class'   => 'btn btn-danger btn-xs',
-                                        'title'   => trans('general.delete'),
-                                        'onclick' => 'confirmDelete("' . '#invoice-payment-' . $payment->id . '", "' . trans_choice('general.payments', 2) . '", "' . trans('general.delete_confirm', ['name' => '<strong>' . Date::parse($payment->paid_at)->format($date_format) . ' - ' . money($payment->amount, $payment->currency_code, true) . ' - ' . $payment->account->name . '</strong>', 'type' => strtolower(trans_choice('general.revenues', 1))]) . '", "' . trans('general.cancel') . '", "' . trans('general.delete') . '")'
-                                    )) !!}
-                                    {!! Form::close() !!}
-                                </td>
+                                <th>{{ trans('general.date') }}</th>
+                                <th>{{ trans('general.amount') }}</th>
+                                <th>{{ trans_choice('general.accounts', 1) }}</th>
+                                <th style="width: 15%;">{{ trans('general.actions') }}</th>
                             </tr>
-                        @endforeach
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                            @foreach($invoice->payments as $payment)
+                                <tr>
+                                    <td>{{ Date::parse($payment->paid_at)->format($date_format) }}</td>
+                                    <td>@money($payment->amount, $payment->currency_code, true)</td>
+                                    <td>{{ $payment->account->name }}</td>
+                                    <td>
+                                        <a href="{{ url('incomes/invoices/' . $payment->id . '') }}" class="btn btn-info btn-xs hidden"><i class="fa fa-eye" aria-hidden="true"></i> {{ trans('general.show') }}</a>
+                                        <a href="{{ url('incomes/revenues/' . $payment->id . '/edit') }}" class="btn btn-primary btn-xs  hidden"><i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{ trans('general.edit') }}</a>
+                                        {!! Form::open([
+                                            'id' => 'invoice-payment-' . $payment->id,
+                                            'method' => 'DELETE',
+                                            'url' => ['incomes/invoices/payment', $payment->id],
+                                            'style' => 'display:inline'
+                                        ]) !!}
+                                        {!! Form::button('<i class="fa fa-trash-o" aria-hidden="true"></i> ' . trans('general.delete'), array(
+                                            'type'    => 'button',
+                                            'class'   => 'btn btn-danger btn-xs',
+                                            'title'   => trans('general.delete'),
+                                            'onclick' => 'confirmDelete("' . '#invoice-payment-' . $payment->id . '", "' . trans_choice('general.payments', 2) . '", "' . trans('general.delete_confirm', ['name' => '<strong>' . Date::parse($payment->paid_at)->format($date_format) . ' - ' . money($payment->amount, $payment->currency_code, true) . ' - ' . $payment->account->name . '</strong>', 'type' => strtolower(trans_choice('general.revenues', 1))]) . '", "' . trans('general.cancel') . '", "' . trans('general.delete') . '")'
+                                        )) !!}
+                                        {!! Form::close() !!}
+                                    </td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
![screen shot 2017-11-28 at 2 16 50 pm](https://user-images.githubusercontent.com/3650559/33307160-1d5793e2-d448-11e7-9dac-c9b306c2a8ea.png)

Histories and Payments section in invoice and bills page overlaps the footer.
By wrapping these section with row class and removing the no-padding-* class will fix this issue.