### PR TITLE
Update popover function call method signature

### DIFF
--- a/resources/views/expenses/bills/create.blade.php
+++ b/resources/views/expenses/bills/create.blade.php
@@ -273,7 +273,7 @@
             });
 
             $('a[rel=popover]').popover({
-                html: 'true',
+                html: true,
                 placement: 'bottom',
                 title: '{{ trans('bills.discount') }}',
                 content: function () {

--- a/resources/views/expenses/bills/edit.blade.php
+++ b/resources/views/expenses/bills/edit.blade.php
@@ -304,7 +304,7 @@
             });
 
             $('a[rel=popover]').popover({
-                html: 'true',
+                html: true,
                 placement: 'bottom',
                 title: '{{ trans('bills.discount') }}',
                 content: function () {

--- a/resources/views/incomes/invoices/create.blade.php
+++ b/resources/views/incomes/invoices/create.blade.php
@@ -272,7 +272,7 @@
             });
 
             $('a[rel=popover]').popover({
-                html: 'true',
+                html: true,
                 placement: 'bottom',
                 title: '{{ trans('invoices.discount') }}',
                 content: function () {

--- a/resources/views/incomes/invoices/edit.blade.php
+++ b/resources/views/incomes/invoices/edit.blade.php
@@ -303,7 +303,7 @@
             });
 
             $('a[rel=popover]').popover({
-                html: 'true',
+                html: true,
                 placement: 'bottom',
                 title: '{{ trans('invoices.discount') }}',
                 content: function () {


### PR DESCRIPTION
Currently on line #275
`$('a[rel=popover]').popover({ html: 'true',`

html true where `'true'` is within quotes, Which causes issue when trying to open popover. As popover expects Boolean. As mentioned at: https://getbootstrap.com/docs/4.0/components/popovers/#options