### PR TITLE
README fix for docker-compose.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Akaunting uses [Laravel](http://laravel.com), the best existing PHP framework, a
 
 ## Docker
 
-It is possible to containerise Akaunting using the [`docker-compose`](docker-compose.yaml) file. Here are a few commands:
+It is possible to containerise Akaunting using the [`docker-compose`](docker-compose.yml) file. Here are a few commands:
 
 ```
 # Build the app


### PR DESCRIPTION
When looking into installing akaunting via docker I noticed that the location for the `docker-compose` file was incorrectly linked. 

Small fix but a fix 🎉 