### PR TITLE
#631 Fixed: Add row button on Invoice and Bill

### DIFF
--- a/resources/views/expenses/bills/create.blade.php
+++ b/resources/views/expenses/bills/create.blade.php
@@ -172,10 +172,11 @@
     <script type="text/javascript">
         var focus = false;
         var item_row = '{{ $item_row }}';
-        var currency_code = $('#currency_code').val();
         var autocomplete_path = "{{ url('common/items/autocomplete') }}";
 
         $(document).ready(function(){
+            var currency_code = $('#currency_code').val();
+
             @if (old('item'))
             $('#vendor_id').trigger('change');
             @endif

--- a/resources/views/expenses/bills/edit.blade.php
+++ b/resources/views/expenses/bills/edit.blade.php
@@ -153,7 +153,6 @@
     <script type="text/javascript">
         var focus = false;
         var item_row = '{{ $item_row }}';
-        var currency_code = $('#currency_code').val();
         var autocomplete_path = "{{ url('common/items/autocomplete') }}";
 
         $(document).on('click', '#button-add-item', function (e) {
@@ -222,6 +221,8 @@
         });
 
         $(document).ready(function(){
+            var currency_code = $('#currency_code').val();
+
             $('#vendor_id').trigger('change');
 
             itemTableResize();

--- a/resources/views/incomes/invoices/create.blade.php
+++ b/resources/views/incomes/invoices/create.blade.php
@@ -172,7 +172,6 @@
     <script type="text/javascript">
         var focus = false;
         var item_row = '{{ $item_row }}';
-        var currency_code = $('#currency_code').val();
         var autocomplete_path = "{{ url('common/items/autocomplete') }}";
 
         $(document).on('click', '#button-add-item', function (e) {
@@ -223,6 +222,8 @@
         });
 
         $(document).ready(function(){
+            var currency_code = $('#currency_code').val();
+
             itemTableResize();
 
             @if (old('item'))


### PR DESCRIPTION
Move the `currency_code` variable in a `$(document).ready` block. 

Currently the `currency_code` variable will always be empty. This is because the script is inserted in the head of the page and the `currency_code` dropdown is not available at that stage. By moving the `currency_code` variable to the document ready section the variable will be filled when the page is loaded.