### PR TITLE
#637 Fixed: Moved popover initialisation to Document ready

### DIFF
--- a/resources/views/expenses/bills/create.blade.php
+++ b/resources/views/expenses/bills/create.blade.php
@@ -240,6 +240,38 @@
                 placeholder: "{{ trans('general.form.select.field', ['field' => trans_choice('general.categories', 1)]) }}"
             });
 
+            // Discount popover
+            $('a[rel=popover]').popover({
+                html: true,
+                placement: 'bottom',
+                title: '{{ trans('bills.discount') }}',
+                content: function () {
+                    html  = '<div class="discount box-body">';
+                    html += '    <div class="col-md-6">';
+                    html += '        <div class="input-group" id="input-discount">';
+                    html += '            {!! Form::number('pre-discount', null, ['id' => 'pre-discount', 'class' => 'form-control text-right']) !!}';
+                    html += '            <div class="input-group-addon"><i class="fa fa-percent"></i></div>';
+                    html += '        </div>';
+                    html += '    </div>';
+                    html += '    <div class="col-md-6">';
+                    html += '        <div class="discount-description">';
+                    html += '           {{ trans('bills.discount_desc') }}';
+                    html += '        </div>';
+                    html += '    </div>';
+                    html += '</div>';
+                    html += '<div class="discount box-footer">';
+                    html += '    <div class="col-md-12">';
+                    html += '        <div class="form-group no-margin">';
+                    html += '            {!! Form::button('<span class="fa fa-save"></span> &nbsp;' . trans('general.save'), ['type' => 'button', 'id' => 'save-discount','class' => 'btn btn-success']) !!}';
+                    html += '            <a href="javascript:void(0)" id="cancel-discount" class="btn btn-default"><span class="fa fa-times-circle"></span> &nbsp;{{ trans('general.cancel') }}</a>';
+                    html += '       </div>';
+                    html += '    </div>';
+                    html += '</div>';
+
+                    return html;
+                }
+            });
+
             $('#attachment').fancyfile({
                 text  : '{{ trans('general.form.select.file') }}',
                 style : 'btn-default',
@@ -352,37 +384,6 @@
                     }
                 }
             });
-        });
-
-        $('a[rel=popover]').popover({
-            html: true,
-            placement: 'bottom',
-            title: '{{ trans('bills.discount') }}',
-            content: function () {
-                html  = '<div class="discount box-body">';
-                html += '    <div class="col-md-6">';
-                html += '        <div class="input-group" id="input-discount">';
-                html += '            {!! Form::number('pre-discount', null, ['id' => 'pre-discount', 'class' => 'form-control text-right']) !!}';
-                html += '            <div class="input-group-addon"><i class="fa fa-percent"></i></div>';
-                html += '        </div>';
-                html += '    </div>';
-                html += '    <div class="col-md-6">';
-                html += '        <div class="discount-description">';
-                html += '           {{ trans('bills.discount_desc') }}';
-                html += '        </div>';
-                html += '    </div>';
-                html += '</div>';
-                html += '<div class="discount box-footer">';
-                html += '    <div class="col-md-12">';
-                html += '        <div class="form-group no-margin">';
-                html += '            {!! Form::button('<span class="fa fa-save"></span> &nbsp;' . trans('general.save'), ['type' => 'button', 'id' => 'save-discount','class' => 'btn btn-success']) !!}';
-                html += '            <a href="javascript:void(0)" id="cancel-discount" class="btn btn-default"><span class="fa fa-times-circle"></span> &nbsp;{{ trans('general.cancel') }}</a>';
-                html += '       </div>';
-                html += '    </div>';
-                html += '</div>';
-
-                return html;
-            }
         });
 
         $(document).on('keyup', '#pre-discount', function(e){

--- a/resources/views/expenses/bills/edit.blade.php
+++ b/resources/views/expenses/bills/edit.blade.php
@@ -221,6 +221,38 @@
                 placeholder: "{{ trans('general.form.select.field', ['field' => trans_choice('general.categories', 1)]) }}"
             });
 
+            // Discount popover
+            $('a[rel=popover]').popover({
+                html: true,
+                placement: 'bottom',
+                title: '{{ trans('bills.discount') }}',
+                content: function () {
+                    html  = '<div class="discount box-body">';
+                    html += '    <div class="col-md-6">';
+                    html += '        <div class="input-group" id="input-discount">';
+                    html += '            {!! Form::number('pre-discount', null, ['id' => 'pre-discount', 'class' => 'form-control text-right']) !!}';
+                    html += '            <div class="input-group-addon"><i class="fa fa-percent"></i></div>';
+                    html += '        </div>';
+                    html += '    </div>';
+                    html += '    <div class="col-md-6">';
+                    html += '        <div class="discount-description">';
+                    html += '           {{ trans('bills.discount_desc') }}';
+                    html += '        </div>';
+                    html += '    </div>';
+                    html += '</div>';
+                    html += '<div class="discount box-footer">';
+                    html += '    <div class="col-md-12">';
+                    html += '        <div class="form-group no-margin">';
+                    html += '            {!! Form::button('<span class="fa fa-save"></span> &nbsp;' . trans('general.save'), ['type' => 'button', 'id' => 'save-discount','class' => 'btn btn-success']) !!}';
+                    html += '            <a href="javascript:void(0)" id="cancel-discount" class="btn btn-default"><span class="fa fa-times-circle"></span> &nbsp;{{ trans('general.cancel') }}</a>';
+                    html += '       </div>';
+                    html += '    </div>';
+                    html += '</div>';
+
+                    return html;
+                }
+            });
+
             $('#attachment').fancyfile({
                 text  : '{{ trans('general.form.select.file') }}',
                 style : 'btn-default',
@@ -360,37 +392,6 @@
                     }
                 }
             });
-        });
-
-        $('a[rel=popover]').popover({
-            html: true,
-            placement: 'bottom',
-            title: '{{ trans('bills.discount') }}',
-            content: function () {
-                html  = '<div class="discount box-body">';
-                html += '    <div class="col-md-6">';
-                html += '        <div class="input-group" id="input-discount">';
-                html += '            {!! Form::number('pre-discount', null, ['id' => 'pre-discount', 'class' => 'form-control text-right']) !!}';
-                html += '            <div class="input-group-addon"><i class="fa fa-percent"></i></div>';
-                html += '        </div>';
-                html += '    </div>';
-                html += '    <div class="col-md-6">';
-                html += '        <div class="discount-description">';
-                html += '           {{ trans('bills.discount_desc') }}';
-                html += '        </div>';
-                html += '    </div>';
-                html += '</div>';
-                html += '<div class="discount box-footer">';
-                html += '    <div class="col-md-12">';
-                html += '        <div class="form-group no-margin">';
-                html += '            {!! Form::button('<span class="fa fa-save"></span> &nbsp;' . trans('general.save'), ['type' => 'button', 'id' => 'save-discount','class' => 'btn btn-success']) !!}';
-                html += '            <a href="javascript:void(0)" id="cancel-discount" class="btn btn-default"><span class="fa fa-times-circle"></span> &nbsp;{{ trans('general.cancel') }}</a>';
-                html += '       </div>';
-                html += '    </div>';
-                html += '</div>';
-
-                return html;
-            }
         });
 
         $(document).on('keyup', '#pre-discount', function(e){

--- a/resources/views/incomes/invoices/create.blade.php
+++ b/resources/views/incomes/invoices/create.blade.php
@@ -240,6 +240,38 @@
                 placeholder: "{{ trans('general.form.select.field', ['field' => trans_choice('general.categories', 1)]) }}"
             });
 
+            // Discount popover
+            $('a[rel=popover]').popover({
+                html: true,
+                placement: 'bottom',
+                title: '{{ trans('invoices.discount') }}',
+                content: function () {
+                    html  = '<div class="discount box-body">';
+                    html += '    <div class="col-md-6">';
+                    html += '        <div class="input-group" id="input-discount">';
+                    html += '            {!! Form::number('pre-discount', null, ['id' => 'pre-discount', 'class' => 'form-control text-right']) !!}';
+                    html += '            <div class="input-group-addon"><i class="fa fa-percent"></i></div>';
+                    html += '        </div>';
+                    html += '    </div>';
+                    html += '    <div class="col-md-6">';
+                    html += '        <div class="discount-description">';
+                    html += '           {{ trans('invoices.discount_desc') }}';
+                    html += '        </div>';
+                    html += '    </div>';
+                    html += '</div>';
+                    html += '<div class="discount box-footer">';
+                    html += '    <div class="col-md-12">';
+                    html += '        <div class="form-group no-margin">';
+                    html += '            {!! Form::button('<span class="fa fa-save"></span> &nbsp;' . trans('general.save'), ['type' => 'button', 'id' => 'save-discount','class' => 'btn btn-success']) !!}';
+                    html += '            <a href="javascript:void(0)" id="cancel-discount" class="btn btn-default"><span class="fa fa-times-circle"></span> &nbsp;{{ trans('general.cancel') }}</a>';
+                    html += '       </div>';
+                    html += '    </div>';
+                    html += '</div>';
+
+                    return html;
+                }
+            });
+
             $('#attachment').fancyfile({
                 text  : '{{ trans('general.form.select.file') }}',
                 style : 'btn-default',
@@ -352,37 +384,6 @@
                     }
                 }
             });
-        });
-
-        $('a[rel=popover]').popover({
-            html: true,
-            placement: 'bottom',
-            title: '{{ trans('invoices.discount') }}',
-            content: function () {
-                html  = '<div class="discount box-body">';
-                html += '    <div class="col-md-6">';
-                html += '        <div class="input-group" id="input-discount">';
-                html += '            {!! Form::number('pre-discount', null, ['id' => 'pre-discount', 'class' => 'form-control text-right']) !!}';
-                html += '            <div class="input-group-addon"><i class="fa fa-percent"></i></div>';
-                html += '        </div>';
-                html += '    </div>';
-                html += '    <div class="col-md-6">';
-                html += '        <div class="discount-description">';
-                html += '           {{ trans('invoices.discount_desc') }}';
-                html += '        </div>';
-                html += '    </div>';
-                html += '</div>';
-                html += '<div class="discount box-footer">';
-                html += '    <div class="col-md-12">';
-                html += '        <div class="form-group no-margin">';
-                html += '            {!! Form::button('<span class="fa fa-save"></span> &nbsp;' . trans('general.save'), ['type' => 'button', 'id' => 'save-discount','class' => 'btn btn-success']) !!}';
-                html += '            <a href="javascript:void(0)" id="cancel-discount" class="btn btn-default"><span class="fa fa-times-circle"></span> &nbsp;{{ trans('general.cancel') }}</a>';
-                html += '       </div>';
-                html += '    </div>';
-                html += '</div>';
-
-                return html;
-            }
         });
 
         $(document).on('keyup', '#pre-discount', function(e){

--- a/resources/views/incomes/invoices/edit.blade.php
+++ b/resources/views/incomes/invoices/edit.blade.php
@@ -221,6 +221,38 @@
                 placeholder: "{{ trans('general.form.select.field', ['field' => trans_choice('general.categories', 1)]) }}"
             });
 
+            // Discount popover
+            $('a[rel=popover]').popover({
+                html: true,
+                placement: 'bottom',
+                title: '{{ trans('invoices.discount') }}',
+                content: function () {
+                    html  = '<div class="discount box-body">';
+                    html += '    <div class="col-md-6">';
+                    html += '        <div class="input-group" id="input-discount">';
+                    html += '            {!! Form::number('pre-discount', null, ['id' => 'pre-discount', 'class' => 'form-control text-right']) !!}';
+                    html += '            <div class="input-group-addon"><i class="fa fa-percent"></i></div>';
+                    html += '        </div>';
+                    html += '    </div>';
+                    html += '    <div class="col-md-6">';
+                    html += '        <div class="discount-description">';
+                    html += '           {{ trans('invoices.discount_desc') }}';
+                    html += '        </div>';
+                    html += '    </div>';
+                    html += '</div>';
+                    html += '<div class="discount box-footer">';
+                    html += '    <div class="col-md-12">';
+                    html += '        <div class="form-group no-margin">';
+                    html += '            {!! Form::button('<span class="fa fa-save"></span> &nbsp;' . trans('general.save'), ['type' => 'button', 'id' => 'save-discount','class' => 'btn btn-success']) !!}';
+                    html += '            <a href="javascript:void(0)" id="cancel-discount" class="btn btn-default"><span class="fa fa-times-circle"></span> &nbsp;{{ trans('general.cancel') }}</a>';
+                    html += '       </div>';
+                    html += '    </div>';
+                    html += '</div>';
+
+                    return html;
+                }
+            });
+
             $('#attachment').fancyfile({
                 text  : '{{ trans('general.form.select.file') }}',
                 style : 'btn-default',
@@ -360,37 +392,6 @@
                     }
                 }
             });
-        });
-
-        $('a[rel=popover]').popover({
-            html: true,
-            placement: 'bottom',
-            title: '{{ trans('invoices.discount') }}',
-            content: function () {
-                html  = '<div class="discount box-body">';
-                html += '    <div class="col-md-6">';
-                html += '        <div class="input-group" id="input-discount">';
-                html += '            {!! Form::number('pre-discount', null, ['id' => 'pre-discount', 'class' => 'form-control text-right']) !!}';
-                html += '            <div class="input-group-addon"><i class="fa fa-percent"></i></div>';
-                html += '        </div>';
-                html += '    </div>';
-                html += '    <div class="col-md-6">';
-                html += '        <div class="discount-description">';
-                html += '           {{ trans('invoices.discount_desc') }}';
-                html += '        </div>';
-                html += '    </div>';
-                html += '</div>';
-                html += '<div class="discount box-footer">';
-                html += '    <div class="col-md-12">';
-                html += '        <div class="form-group no-margin">';
-                html += '            {!! Form::button('<span class="fa fa-save"></span> &nbsp;' . trans('general.save'), ['type' => 'button', 'id' => 'save-discount','class' => 'btn btn-success']) !!}';
-                html += '            <a href="javascript:void(0)" id="cancel-discount" class="btn btn-default"><span class="fa fa-times-circle"></span> &nbsp;{{ trans('general.cancel') }}</a>';
-                html += '       </div>';
-                html += '    </div>';
-                html += '</div>';
-
-                return html;
-            }
         });
 
         $(document).on('keyup', '#pre-discount', function(e){


### PR DESCRIPTION
Move the popover initialisation inside the `$(document).ready` block. This is will make sure that the element that the popover is initialised on is actually available in the DOM.