### PR TITLE
No need to mount a folder you already copied in the image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
       MYSQL_PASSWORD: akaunting_password
   web:
     image: akaunting
-    volumes:
-      - ./:/var/www/html
     ports:
       - 8080:80
     environment:


### PR DESCRIPTION
Plus, it generated access errrors.