### PR TITLE
fix bill and invoice reminders

### DIFF
--- a/app/Models/Expense/Bill.php
+++ b/app/Models/Expense/Bill.php
@@ -115,7 +115,7 @@ class Bill extends Model
 
     public function scopeDue($query, $date)
     {
-        return $query->where('due_at', '=', $date);
+        return $query->whereDate('due_at', '=', $date);
     }
 
     public function scopeLatest($query)

--- a/app/Models/Income/Invoice.php
+++ b/app/Models/Income/Invoice.php
@@ -118,7 +118,7 @@ class Invoice extends Model
 
     public function scopeDue($query, $date)
     {
-        return $query->where('due_at', '=', $date);
+        return $query->whereDate('due_at', '=', $date);
     }
 
     public function scopeLatest($query)

--- a/database/seeds/TestCompany.php
+++ b/database/seeds/TestCompany.php
@@ -49,6 +49,10 @@ class TestCompany extends Seeder
         Setting::set('general.default_currency', 'USD');
         Setting::set('general.default_account', '1');
         Setting::set('general.default_payment_method', 'offlinepayment.cash.1');
+        Setting::set('general.schedule_bill_days', '10,5,3,1');
+        Setting::set('general.schedule_invoice_days', '1,3,5,10');
+        Setting::set('general.send_invoice_reminder', true);
+        Setting::set('general.send_bill_reminder', true);
         Setting::save();
 
         $this->command->info('Test company created.');

--- a/tests/Feature/Commands/BillReminderTest.php
+++ b/tests/Feature/Commands/BillReminderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use App\Models\Expense\Bill;
+use App\Notifications\Expense\Bill as BillNotification;
+use Illuminate\Support\Facades\Notification;
+use Jenssegers\Date\Date;
+use Tests\Feature\FeatureTestCase;
+
+class BillReminderTest extends FeatureTestCase
+{
+    private $addDay;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->addDay = 3;
+    }
+
+    public function testBillReminderByDueDate()
+    {
+        Notification::fake();
+
+        $bill = Bill::create($this->getBillRequest());
+
+        Date::setTestNow(Date::now()->subDays($this->addDay));
+
+        $this->artisan('reminder:bill');
+
+        Notification::assertSentTo(
+            $this->user,
+            BillNotification::class,
+            function ($notification, $channels) use ($bill) {
+                return $notification->bill->id === $bill->id;
+            }
+        );
+    }
+
+    /**
+     * Copied in InvoicesTest
+     *
+     * @param int $recurring
+     * @return array
+     */
+    private function getBillRequest()
+    {
+        $amount = $this->faker->randomFloat(2, 2);
+
+        $items = [['name' => $this->faker->text(5), 'item_id' => null, 'quantity' => '1', 'price' => $amount, 'currency' => 'USD']];
+
+
+        $data = [
+            'vendor_id' => '0',
+            'billed_at' => $this->faker->date(),
+            'due_at' => Date::now()->subDays($this->addDay - 1),
+            'bill_number' => '1',
+            'order_number' => '1',
+            'currency_code' => setting('general.default_currency'),
+            'currency_rate' => '1',
+            'item' => $items,
+            'discount' => '0',
+            'notes' => $this->faker->text(5),
+            'category_id' => $this->company->categories()->type('income')->first()->id,
+            'recurring_frequency' => 'no',
+            'vendor_name' => $this->faker->name,
+            'vendor_email' => $this->faker->email,
+            'vendor_tax_number' => null,
+            'vendor_phone' => null,
+            'vendor_address' => $this->faker->address,
+            'bill_status_code' => 'sent',
+            'amount' => $amount,
+            'company_id' => $this->company->id,
+        ];
+
+
+        return $data;
+    }
+}

--- a/tests/Feature/Commands/InvoiceReminderTest.php
+++ b/tests/Feature/Commands/InvoiceReminderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use App\Models\Income\Invoice;
+use App\Notifications\Income\Invoice as InvoiceNotification;
+use Illuminate\Support\Facades\Notification;
+use Jenssegers\Date\Date;
+use Tests\Feature\FeatureTestCase;
+
+class InvoiceReminderTest extends FeatureTestCase
+{
+    private $addDay;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->addDay = 3;
+    }
+
+    public function testInvoiceReminderByDueDate()
+    {
+        Notification::fake();
+
+        $invoice = Invoice::create($this->getInvoiceRequest());
+
+        Date::setTestNow(Date::now()->addDay($this->addDay));
+
+        $this->artisan('reminder:invoice');
+
+        Notification::assertSentTo(
+            $this->user,
+            InvoiceNotification::class,
+            function ($notification, $channels) use ($invoice) {
+                return $notification->invoice->id === $invoice->id;
+            }
+        );
+    }
+
+    /**
+     * Copied in InvoicesTest
+     *
+     * @param int $recurring
+     * @return array
+     */
+    private function getInvoiceRequest($recurring = 0)
+    {
+        $amount = $this->faker->randomFloat(2, 2);
+
+        $items = [['name' => $this->faker->text(5), 'item_id' => null, 'quantity' => '1', 'price' => $amount, 'currency' => 'USD']];
+
+
+        $data = [
+            'customer_id' => '0',
+            'invoiced_at' => $this->faker->date(),
+            'due_at' => Date::now()->addDay($this->addDay - 1),
+            'invoice_number' => '1',
+            'order_number' => '1',
+            'currency_code' => setting('general.default_currency'),
+            'currency_rate' => '1',
+            'item' => $items,
+            'discount' => '0',
+            'notes' => $this->faker->text(5),
+            'category_id' => $this->company->categories()->type('income')->first()->id,
+            'recurring_frequency' => 'no',
+            'customer_name' => $this->faker->name,
+            'customer_email' => $this->faker->email,
+            'customer_tax_number' => null,
+            'customer_phone' => null,
+            'customer_address' => $this->faker->address,
+            'invoice_status_code' => 'sent',
+            'amount' => $amount,
+            'company_id' => $this->company->id,
+        ];
+
+        if ($recurring) {
+            $data['recurring_frequency'] = 'yes';
+            $data['recurring_interval'] = '1';
+            $data['recurring_custom_frequency'] = $this->faker->randomElement(['monthly', 'weekly']);
+            $data['recurring_count'] = '1';
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
Bill and invoice reminders does not work because the checked date format is different than `due_at`.