### PR TITLE
Remove passing of unused variable

### DIFF
--- a/app/Http/Controllers/Incomes/Customers.php
+++ b/app/Http/Controllers/Incomes/Customers.php
@@ -29,7 +29,7 @@ class Customers extends Controller
     {
         $customers = Customer::collect();
 
-        return view('incomes.customers.index', compact('customers', 'emails'));
+        return view('incomes.customers.index', compact('customers'));
     }
 
     /**


### PR DESCRIPTION
In PHP 7.3, calling `compact` on variables that aren't declared will throw an exception:

```
[2018-12-25 17:17:23] production.ERROR: ErrorException: compact(): Undefined variable: emails in /app/Http/Controllers/Incomes/Customers.php:32
```