### PR TITLE
fix invoice export crash when has a tax without items

### DIFF
--- a/app/Http/Controllers/Incomes/Invoices.php
+++ b/app/Http/Controllers/Incomes/Invoices.php
@@ -286,7 +286,7 @@ class Invoices extends Controller
             $tables = ['items', 'histories', 'payments', 'totals'];
             foreach ($tables as $table) {
                 $excel->sheet('invoice_' . $table, function ($sheet) use ($invoices, $table) {
-                    $hidden_fields = ['id', 'company_id', 'created_at', 'updated_at', 'deleted_at', 'title'];
+                    $hidden_fields = ['id', 'company_id', 'created_at', 'updated_at', 'deleted_at', 'title', 'tax_id'];
 
                     $i = 1;
 


### PR DESCRIPTION
it should fix #710 

that issue will happen when 1 of item has no tax. 