### PR TITLE
The switch button "Show to customer" is always On

### DIFF
--- a/modules/OfflinePayment/Resources/views/edit.blade.php
+++ b/modules/OfflinePayment/Resources/views/edit.blade.php
@@ -153,7 +153,7 @@
                             $('input[name="name"]').val(json['data']['name']);
                             $('input[name="code"]').val(json['data']['code']);
 
-                            if (json['data']['customer']) {
+                            if (json['data']['customer'] == 1) {
                                 $('#customer_1 input').trigger('click');
                             } else {
                                 $('#customer_0 input').trigger('click');


### PR DESCRIPTION
- Akaunting version : 1.3.8
## Steps to reproduce
- Settings > Offline Payments
- Edit an existing row and make it not be shown to the customer
- Save
- Edit again, it is supposed to be No. But it is alawys Yes in the IHM.

## DB :
In the data base the data is correct : "customer":0 the same in the response of the ajax call

## Comments
In the interface of "Offline Payments" the radio button is always On even if the "customer" attribute is 1.