### PR TITLE
Improved presentation for smaller screens

### DIFF
--- a/resources/views/expenses/bills/show.blade.php
+++ b/resources/views/expenses/bills/show.blade.php
@@ -335,7 +335,7 @@
     </div>
 
     <div class="row">
-        <div class="col-xs-6">
+        <div class="col-md-6 col-sm-12">
             <div class="box box-default collapsed-box">
                 <div class="box-header with-border">
                     <h3 class="box-title">{{ trans('bills.histories') }}</h3>
@@ -370,7 +370,7 @@
             </div>
         </div>
 
-        <div class="col-xs-6">
+        <div class="col-md-6 col-sm-12">
             <div class="box box-default collapsed-box">
                 <div class="box-header with-border">
                     <h3 class="box-title">{{ trans('bills.payments') }}</h3>


### PR DESCRIPTION
The payments and histories being stacked side-by-side works well for medium screen upwards, but on small devices (phones) the view makes it rather difficult to read.

This change improves legibility on mobile gadgets.