### PR TITLE
Limiting selectable taxes based on type

### DIFF
--- a/app/Http/Controllers/Expenses/Bills.php
+++ b/app/Http/Controllers/Expenses/Bills.php
@@ -99,10 +99,13 @@ class Bills extends Controller
         $items = Item::enabled()->orderBy('name')->pluck('name', 'id');
 
         $taxes = Tax::enabled()->orderBy('name')->get()->pluck('title', 'id');
+        $taxes_attributes = Tax::enabled()->orderBy('name')->get()->mapWithKeys(function ($t) {
+            return [$t->id => ['data-type' => $t->type]]; 
+        })->all();
 
         $categories = Category::enabled()->type('expense')->orderBy('name')->pluck('name', 'id');
 
-        return view('expenses.bills.create', compact('vendors', 'currencies', 'currency', 'items', 'taxes', 'categories'));
+        return view('expenses.bills.create', compact('vendors', 'currencies', 'currency', 'items', 'taxes', 'categories', 'taxes_attributes'));
     }
 
     /**
@@ -523,6 +526,9 @@ class Bills extends Controller
         $currency_code = $request['currency_code'];
 
         $taxes = Tax::enabled()->orderBy('rate')->get()->pluck('title', 'id');
+        $taxes_attributes = Tax::enabled()->orderBy('name')->get()->mapWithKeys(function ($t) {
+            return [$t->id => ['data-type' => $t->type]]; 
+        })->all();
 
         $currency = Currency::where('code', '=', $currency_code)->first();
 
@@ -535,7 +541,7 @@ class Bills extends Controller
             $currency->precision = (int) $currency->precision;
         }
 
-        $html = view('expenses.bills.item', compact('item_row', 'taxes', 'currency'))->render();
+        $html = view('expenses.bills.item', compact('item_row', 'taxes', 'currency', 'taxes_attributes'))->render();
 
         return response()->json([
             'success' => true,

--- a/resources/views/expenses/bills/item.blade.php
+++ b/resources/views/expenses/bills/item.blade.php
@@ -35,7 +35,7 @@
     @stack('taxes_td_start')
     <td {{ $errors->has('item.' . $item_row . '.tax_id') ? 'class="has-error"' : '' }}>
         @stack('tax_id_input_start')
-        {!! Form::select('item[' . $item_row . '][tax_id][]', $taxes, (empty($item) || empty($item->taxes)) ? setting('general.default_tax') : $item->taxes->pluck('tax_id'), ['id'=> 'item-tax-' . $item_row, 'class' => 'form-control tax-select2', 'multiple' => 'true']) !!}
+        {!! Form::select('item[' . $item_row . '][tax_id][]', $taxes, (empty($item) || empty($item->taxes)) ? setting('general.default_tax') : $item->taxes->pluck('tax_id'), ['id'=> 'item-tax-' . $item_row, 'class' => 'form-control tax-select2', 'multiple' => 'true'], $taxes_attributes) !!}
         {!! $errors->first('item.' . $item_row . '.tax_id', '<p class="help-block">:message</p>') !!}
         @stack('tax_id_input_end')
     </td>


### PR DESCRIPTION
Issue was described in #688 that based on the way taxes are calculated, inclusive and other types are not compatible for simultaneous use.

This PR tries to address this by UI adjustments.