### PR TITLE
Improve dropdown for custom financial year

### DIFF
--- a/app/Http/ViewComposers/Index.php
+++ b/app/Http/ViewComposers/Index.php
@@ -23,8 +23,17 @@ class Index
 
         $years = [];
         $y = $now->addYears(2);
+
         for ($i = 0; $i < 10; $i++) {
             $years[$y->year] = $y->year;
+            
+            if (Date::parse(setting('general.financial_start'))->month != 1) {
+                $nY = $y->year + 1;
+                // format the dropdown text to indicate that the next
+                // calendar year is part of financial year
+                $years[$y->year] = "{$y->year}-{$nY}";
+            }
+
             $y->subYear();
         }
 


### PR DESCRIPTION
Currently the dropdown on reports just shows a year which doesn't have much of a meaning when talking about financial years start from a month other than January.

This PR improves the clarity on this subject.