### PR TITLE
Include links to bills on relevant transactions

### DIFF
--- a/app/Http/Controllers/Banking/Transactions.php
+++ b/app/Http/Controllers/Banking/Transactions.php
@@ -71,6 +71,7 @@ class Transactions extends Controller
 
             $this->transactions[] = (object) [
                 'paid_at'           => $item->paid_at,
+                'bill_id'           => $item->bill_id,
                 'account_name'      => $item->account->name,
                 'type'              => $type,
                 'description'       => $item->description,

--- a/resources/views/banking/transactions/index.blade.php
+++ b/resources/views/banking/transactions/index.blade.php
@@ -44,7 +44,13 @@
                         <td>{{ $item->type }}</td>
                         <td>{{ $item->category_name }}</td>
                         <td>{{ $item->description }}</td>
+                        @if(!is_null($item->bill_id))
+                        <td class="text-right amount-space">
+                            <a href="{{ route('bills.show', $item->bill_id) }}">@money($item->amount, $item->currency_code, true)</a>
+                        </td>
+                        @else
                         <td class="text-right amount-space">@money($item->amount, $item->currency_code, true)</td>
+                        @endif
                     </tr>
                 @endforeach
                 </tbody>


### PR DESCRIPTION
In the current setup, the transaction page lists the amounts and other details. However, when there are many bills on an account, it's not straightforward to identify which transaction corresponds to which bill (especially when payments have been performed in multiple transactions)

This PR adds hyperlinks to the amount to ease the identification of the relevant bill.