### PR TITLE
Fix create response in invoice payments API

### DIFF
--- a/app/Http/Controllers/Api/Incomes/InvoicePayments.php
+++ b/app/Http/Controllers/Api/Incomes/InvoicePayments.php
@@ -105,7 +105,7 @@ class InvoicePayments extends BaseController
 
         InvoiceHistory::create($request->input());
 
-        return $this->response->created(url('api/invoices/' . $invoice_id . '/payments' . $invoice_payment->id));
+        return $this->response->created(url('api/invoices/' . $invoice_id . '/payments/' . $invoice_payment->id));
     }
 
     /**


### PR DESCRIPTION
Hi!  While working with the Akaunting API (integrating it with some various other systems we've got in place), I noticed a small bug when creating invoice payments via the API.  The URL passed in the Location: header was missing a slash.  I went ahead and added it 😃 