### PR TITLE
Issue with print Invoices

### DIFF
--- a/app/Http/ViewComposers/Logo.php
+++ b/app/Http/ViewComposers/Logo.php
@@ -36,7 +36,7 @@ class Logo
                 return $logo;
             }
         } else {
-            $path = asset('public/img/company.png');
+            $path = 'public/img/company.png';
         }
 
         $image = Image::make($path)->encode()->getEncoded();


### PR DESCRIPTION
Issue with print Invoices - error Image::make #873
When we try to open an invoice print without logo, it call the fallback option of default logo on line 39 of file app/Http/ViewComposers/Logo.php
$path = asset('public/img/company.png');
500 Error on Image::make
cannot read the complete url of default file

When we change the code to:
file app/Http/ViewComposers/Logo.php
39: $path = 'public/img/company.png';

It works fine!