### PR TITLE
Code Improvement - Select Invoice Items with 0 quantity - Items.php

### DIFF
--- a/app/Http/Controllers/Common/Items.php
+++ b/app/Http/Controllers/Common/Items.php
@@ -264,10 +264,6 @@ class Items extends Controller
             'sku' => $query,
         ]);
 
-        if ($type == 'invoice') {
-            $autocomplete->quantity();
-        }
-
         $items = $autocomplete->get();
 
         if ($items) {


### PR DESCRIPTION
When we remove this condition we can select items with 0 stock quantity on Invoices.
Suggest to make it as an option in settings.