### PR TITLE
Bulk action class discovery for modules

### DIFF
--- a/app/Http/ViewComposers/Index.php
+++ b/app/Http/ViewComposers/Index.php
@@ -38,7 +38,7 @@ class Index
         if (Str::contains($view_name, '::')) {
             $names = explode('::', $view_name);
 
-            $params = explode('.', $view_name);
+            $params = explode('.', $names[1]);
 
             $type = $params[0];
 


### PR DESCRIPTION
Current way of discovering bulk action class for modules is using the view.

`Blade: moduleName::group.blade` will search for a bulk action class `Module\
moduleName\BulkActions\moduleName::group`

