### PR TITLE
Include links to bills on relevant transactions

### DIFF
--- a/app/Http/Controllers/Banking/Transactions.php
+++ b/app/Http/Controllers/Banking/Transactions.php
@@ -28,7 +28,7 @@ class Transactions extends Controller
         $request_type = !request()->has('type') ? ['income', 'expense'] : request('type');
         $categories = Category::enabled()->type($request_type)->orderBy('name')->pluck('name', 'id');
 
-        $transactions = Transaction::with(['account', 'category', 'contact', 'bill:id'])->collect(['paid_at'=> 'desc']);
+        $transactions = Transaction::with(['account', 'category', 'contact', 'bill:id', 'invoice.id'])->collect(['paid_at'=> 'desc']);
 
         return view('banking.transactions.index', compact('transactions', 'accounts', 'types', 'categories'));
     }

--- a/app/Http/Controllers/Banking/Transactions.php
+++ b/app/Http/Controllers/Banking/Transactions.php
@@ -28,7 +28,7 @@ class Transactions extends Controller
         $request_type = !request()->has('type') ? ['income', 'expense'] : request('type');
         $categories = Category::enabled()->type($request_type)->orderBy('name')->pluck('name', 'id');
 
-        $transactions = Transaction::with(['account', 'category', 'contact'])->collect(['paid_at'=> 'desc']);
+        $transactions = Transaction::with(['account', 'category', 'contact'])->with('bill:id')->collect(['paid_at'=> 'desc']);
 
         return view('banking.transactions.index', compact('transactions', 'accounts', 'types', 'categories'));
     }

--- a/app/Http/Controllers/Banking/Transactions.php
+++ b/app/Http/Controllers/Banking/Transactions.php
@@ -28,7 +28,7 @@ class Transactions extends Controller
         $request_type = !request()->has('type') ? ['income', 'expense'] : request('type');
         $categories = Category::enabled()->type($request_type)->orderBy('name')->pluck('name', 'id');
 
-        $transactions = Transaction::with(['account', 'category', 'contact'])->with('bill:id')->collect(['paid_at'=> 'desc']);
+        $transactions = Transaction::with(['account', 'category', 'contact', 'bill:id'])->collect(['paid_at'=> 'desc']);
 
         return view('banking.transactions.index', compact('transactions', 'accounts', 'types', 'categories'));
     }

--- a/resources/views/banking/transactions/index.blade.php
+++ b/resources/views/banking/transactions/index.blade.php
@@ -46,14 +46,20 @@
                             <td class="col-xs-4 col-sm-3 col-md-2">{{ trans_choice('general.' . Str::plural($item->type), 1) }}</td>
                             <td class="col-sm-2 col-md-2 hidden-sm">{{ $item->category->name }}</td>
                             <td class="col-md-2 hidden-md">{{ $item->description }}</td>
-                            @if(is_null(data_get($item, 'bill.id')))
-                            <td class="col-xs-4 col-sm-2 col-md-2 text-right">@money($item->amount, $item->currency_code, true)</td>
-                            @else
+                            @if(!is_null(data_get($item, 'bill.id')))
                             <td class="col-xs-4 col-sm-2 col-md-2 text-right">
                                 <a href="{{ route('bills.show', $item->bill->id) }}">
                                     @money($item->amount, $item->currency_code, true)
                                 </a>
                             </td>
+                            @elseif(!is_null(data_get($item, 'invoice.id')))
+                            <td class="col-xs-4 col-sm-2 col-md-2 text-right">
+                                <a href="{{ route('invoices.show', $item->invoice->id) }}">
+                                    @money($item->amount, $item->currency_code, true)
+                                </a>
+                            </td>
+                            @else
+                            <td class="col-xs-4 col-sm-2 col-md-2 text-right">@money($item->amount, $item->currency_code, true)</td>
                             @endif
                         </tr>
                     @endforeach

--- a/resources/views/banking/transactions/index.blade.php
+++ b/resources/views/banking/transactions/index.blade.php
@@ -46,7 +46,14 @@
                             <td class="col-xs-4 col-sm-3 col-md-2">{{ trans_choice('general.' . Str::plural($item->type), 1) }}</td>
                             <td class="col-sm-2 col-md-2 hidden-sm">{{ $item->category->name }}</td>
                             <td class="col-md-2 hidden-md">{{ $item->description }}</td>
-                            <td class="col-xs-4 col-sm-2 col-md-2 text-right">@money($item->amount, $item->currency_code, true)</td>
+                            @if(!is_null($item->bill_id))
+                            @else
+                            <td class="col-xs-4 col-sm-2 col-md-2 text-right">
+                                <a href="{{ route('bills.show', $item->bill_id) }}">
+                                    @money($item->amount, $item->currency_code, true)
+                                </a>
+                            </td>
+                            @endif
                         </tr>
                     @endforeach
                 </tbody>

--- a/resources/views/banking/transactions/index.blade.php
+++ b/resources/views/banking/transactions/index.blade.php
@@ -46,10 +46,10 @@
                             <td class="col-xs-4 col-sm-3 col-md-2">{{ trans_choice('general.' . Str::plural($item->type), 1) }}</td>
                             <td class="col-sm-2 col-md-2 hidden-sm">{{ $item->category->name }}</td>
                             <td class="col-md-2 hidden-md">{{ $item->description }}</td>
-                            @if(!is_null($item->bill_id))
+                            @if(!is_null(data_get($item, 'bill.id')))
                             @else
                             <td class="col-xs-4 col-sm-2 col-md-2 text-right">
-                                <a href="{{ route('bills.show', $item->bill_id) }}">
+                                <a href="{{ route('bills.show', $item->bill->id) }}">
                                     @money($item->amount, $item->currency_code, true)
                                 </a>
                             </td>

--- a/resources/views/banking/transactions/index.blade.php
+++ b/resources/views/banking/transactions/index.blade.php
@@ -46,7 +46,8 @@
                             <td class="col-xs-4 col-sm-3 col-md-2">{{ trans_choice('general.' . Str::plural($item->type), 1) }}</td>
                             <td class="col-sm-2 col-md-2 hidden-sm">{{ $item->category->name }}</td>
                             <td class="col-md-2 hidden-md">{{ $item->description }}</td>
-                            @if(!is_null(data_get($item, 'bill.id')))
+                            @if(is_null(data_get($item, 'bill.id')))
+                            <td class="col-xs-4 col-sm-2 col-md-2 text-right">@money($item->amount, $item->currency_code, true)</td>
                             @else
                             <td class="col-xs-4 col-sm-2 col-md-2 text-right">
                                 <a href="{{ route('bills.show', $item->bill->id) }}">


### PR DESCRIPTION
_This PR is renewed to work with v2 of akaunting_

In the current setup, the transaction page lists the amounts and other details. However, when there are many bills on an account, it's not straightforward to identify which transaction corresponds to which bill (especially when payments have been performed in multiple transactions)

This PR adds hyperlinks to the amount to ease the identification of the relevant bill.