### PR TITLE
Error while running `php artisan install ...` if mysql/mariadb has `d…

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -57,7 +57,7 @@ return [
             'prefix' => env('DB_PREFIX', 'ak_'),
             'prefix_indexes' => true,
             'strict' => true,
-            'engine' => null,
+            'engine' => 'InnoDB ROW_FORMAT=DYNAMIC',
             'modes' => [
                 //'ONLY_FULL_GROUP_BY', // conflicts with eloquence
                 'STRICT_TRANS_TABLES',


### PR DESCRIPTION
Error while running `php artisan install ...` if mysql/mariadb has `default-storage-engine=MYISAM` instead of `InnoDB`. This will ensure that you won't get this error in any case.

Fix to SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 1000 bytes 