### PR TITLE
Allow different field sizes across modules & more

### DIFF
--- a/resources/views/partials/form/text_group.blade.php
+++ b/resources/views/partials/form/text_group.blade.php
@@ -1,10 +1,11 @@
 @stack($name . '_input_start')
 
 <div
-    class="form-group {{ $col }} {{ isset($attributes['required']) ? 'required' : '' }}"
+    class="form-group {{ isset($attributes['col']) ? $attributes['col'] : $col }} {{ isset($attributes['required']) ? 'required' : '' }}"
     :class="[{'has-error': {{ isset($attributes['v-error']) ? $attributes['v-error'] : 'form.errors.get("' . $name . '")' }} }]">
     {!! Form::label($name, $text, ['class' => 'form-control-label'])!!}
 
+    @if(($icon) && ($icon != ''))
     <div class="input-group input-group-merge {{ $group_class }}">
         <div class="input-group-prepend">
             <span class="input-group-text">
@@ -19,6 +20,15 @@
             'v-model' => !empty($attributes['v-model']) ? $attributes['v-model'] : 'form.' . $name
         ], $attributes)) !!}
     </div>
+    @else
+    {!! Form::text($name, $value, array_merge([
+        'class' => 'form-control',
+        'data-name' => $name,
+        'data-value' => $value,
+        'placeholder' => trans('general.form.enter', ['field' => $text]),
+        'v-model' => !empty($attributes['v-model']) ? $attributes['v-model'] : 'form.' . $name
+    ], $attributes)) !!}
+    @endif
 
     <div class="invalid-feedback d-block"
          v-if="{{ isset($attributes['v-error']) ? $attributes['v-error'] : 'form.errors.has("' . $name . '")' }}"


### PR DESCRIPTION
Allow different field sizes across modules and remove icon space when not defined
exemple setting from module:
"settings": [
        {
            "type": "textGroup",
            "name": "username",
            "title": "nfsebru::general.username",
            "icon": "",
            "attributes": {
                "required": "required",
                "col": "col-md-3"
            }
        },