### PR TITLE
validation rules should be seperated from attributes

### DIFF
--- a/app/Http/Requests/Setting/Module.php
+++ b/app/Http/Requests/Setting/Module.php
@@ -29,8 +29,8 @@ class Module extends FormRequest
 
         if ($module->get('settings')) {
             foreach ($module->get('settings') as $field) {
-                if (isset($field['attributes']['required'])) {
-                    $rules[$field['name']] = $field['attributes']['required'];
+                if (isset($field['rules'])) {
+                    $rules[$field['name']] = $field['rules'];
                 }
             }
         }

--- a/modules/PaypalStandard/module.json
+++ b/modules/PaypalStandard/module.json
@@ -20,7 +20,8 @@
             "icon": "fa fa-font",
             "attributes": {
                 "required": "required"
-            }
+            },
+            "rules": "required"
         },
         {
             "type": "textGroup",
@@ -29,7 +30,8 @@
             "icon": "envelope",
             "attributes": {
                 "required": "required"
-            }
+            },
+            "rules": "required"
         },
         {
             "type": "selectGroup",


### PR DESCRIPTION
If you have only "required" validation, there would not be any problem to use attributes.
But if you would like to make validation that value must be integer and have min and max, attributes are insufficient.
Applying Laravel validation rules to fields becomes easy in this way.