### PR TITLE
Don't overwrite the bg-variant mixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "vue-clipboard2": "^0.3.1",
         "vue-flatpickr-component": "^8.1.3",
         "vue-router": "^3.1.3",
-        "vue2-transitions": "^0.2.3"
+        "vue2-transitions": "^0.3.0"
     },
     "devDependencies": {
         "@vue/cli-plugin-babel": "^3.11.0",

--- a/resources/assets/sass/core/mixins/_background-variant.scss
+++ b/resources/assets/sass/core/mixins/_background-variant.scss
@@ -1,16 +1,3 @@
-// Contextual backgrounds
-@mixin bg-variant($parent, $color) {
-    #{$parent} {
-        background-color: $color !important;
-    }
-    a#{$parent},
-    button#{$parent} {
-        @include hover-focus {
-            background-color: darken($color, 10%) !important;
-        }
-    }
-}
-
 @mixin bg-gradient-variant($parent, $color) {
     #{$parent} {
         background: linear-gradient(87deg, $color 0, adjust-hue($color, 25%) 100%) !important;


### PR DESCRIPTION
Bootstrap 4.3 introduced an additional parameter, and npm run dev fails
because we are overwriting a mixin that bootstrap uses internally.

Also update the vue2-transition module to the same version of the dev..