### PR TITLE
fix: adding discount_amounth_total for empty items on invoice creation

### DIFF
--- a/app/Jobs/Sale/CreateInvoice.php
+++ b/app/Jobs/Sale/CreateInvoice.php
@@ -175,7 +175,7 @@ class CreateInvoice extends Job
         $taxes = [];
 
         if (empty($this->request['items'])) {
-            return [$sub_total, $taxes];
+            return [$sub_total, $discount_amount_total, $taxes];
         }
 
         foreach ((array) $this->request['items'] as $item) {


### PR DESCRIPTION
This fixes an error where if you delete the first [default and oly] row when creating a new invoice and save a Flash message of "Undefined offset 2" is returned.