### PR TITLE
Changing extended class on request stub

### DIFF
--- a/app/Console/Stubs/Modules/request.stub
+++ b/app/Console/Stubs/Modules/request.stub
@@ -2,7 +2,7 @@
 
 namespace $NAMESPACE$;
 
-use Illuminate\Foundation\Http\FormRequest;
+use App\Abstracts\Http\FormRequest;
 
 class $CLASS$ extends FormRequest
 {


### PR DESCRIPTION
app/Console/Stubs/Modules/request.stub is updated in order to extend App\Abstracts\Http\FormRequest