### PR TITLE
texts overlapping the first and second column on reports is fixed

### DIFF
--- a/resources/views/partials/reports/table/rows.blade.php
+++ b/resources/views/partials/reports/table/rows.blade.php
@@ -1,6 +1,6 @@
 @php $row_total = 0; @endphp
 <tr class="row rp-border-top-1 font-size-unset">
-    <td class="{{ $class->column_name_width }}">{{ $class->row_names[$table][$id] }}</td>
+    <td class="{{ $class->column_name_width }} long-texts pr-0">{{ $class->row_names[$table][$id] }}</td>
     @foreach($rows as $row)
         @php $row_total += $row; @endphp
         <td class="{{ $class->column_value_width }} text-right px-0">@money($row, setting('default.currency'), true)</td>


### PR DESCRIPTION
There is an example on below screenshot.
![image](https://user-images.githubusercontent.com/16224533/79763785-31c54400-832d-11ea-91f3-01842dc6d4d2.png)
