### PR TITLE
Use config helper instead of env in application code

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -23,11 +23,11 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         // Not installed yet
-        if (!env('APP_INSTALLED')) {
+        if (!config('app.installed')) {
             return;
         }
 
-        $schedule_time = env('APP_SCHEDULE_TIME', '09:00');
+        $schedule_time = config('app.schedule_time');
 
         $schedule->command('reminder:invoice')->dailyAt($schedule_time);
         $schedule->command('reminder:bill')->dailyAt($schedule_time);

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -54,7 +54,7 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $exception)
     {
-        if (env('APP_DEBUG') === false) {
+        if (config('app.debug') === false) {
             return $this->handleExceptions($request, $exception);
         }
 

--- a/app/Http/Controllers/Auth/Login.php
+++ b/app/Http/Controllers/Auth/Login.php
@@ -115,7 +115,7 @@ class Login extends Controller
         auth()->logout();
 
         // Session destroy is required if stored in database
-        if (env('SESSION_DRIVER') == 'database') {
+        if (config('session.driver') == 'database') {
             $request = app('Illuminate\Http\Request');
             $request->session()->getHandler()->destroy($request->session()->getId());
         }

--- a/app/Http/Controllers/Install/Database.php
+++ b/app/Http/Controllers/Install/Database.php
@@ -27,8 +27,10 @@ class Database extends Controller
      */
     public function store(Request $request)
     {
+        $connection = config('database.default','mysql');
+
         $host     = $request['hostname'];
-        $port     = env('DB_PORT', '3306');
+        $port     = config("database.connections.$connection.port", '3306');
         $database = $request['database'];
         $username = $request['username'];
         $password = $request['password'];

--- a/app/Http/ViewComposers/Notifications.php
+++ b/app/Http/ViewComposers/Notifications.php
@@ -19,7 +19,7 @@ class Notifications
     public function compose(View $view)
     {
         // No need to add suggestions in console
-        if (app()->runningInConsole() || !env('APP_INSTALLED') || !user()) {
+        if (app()->runningInConsole() || !config('app.installed') || !user()) {
             return;
         }
 

--- a/app/Http/ViewComposers/Suggestions.php
+++ b/app/Http/ViewComposers/Suggestions.php
@@ -20,7 +20,7 @@ class Suggestions
     public function compose(View $view)
     {
         // No need to add suggestions in console
-        if (app()->runningInConsole() || !env('APP_INSTALLED')) {
+        if (app()->runningInConsole() || !config('app.installed')) {
             return;
         }
 
@@ -31,10 +31,10 @@ class Suggestions
 
             if ($path) {
                 $suggestions = $this->getSuggestions($path);
-    
+
                 if ($suggestions) {
                     $suggestion_modules = $suggestions->modules;
-    
+
                     foreach ($suggestion_modules as $key => $module) {
                         $installed = Module::where('company_id', session('company_id'))->where('alias', $module->alias)->first();
 

--- a/app/Listeners/Update/V20/Version207.php
+++ b/app/Listeners/Update/V20/Version207.php
@@ -26,7 +26,7 @@ class Version207 extends Listener
 
         // Update .env file
         Installer::updateEnv([
-            'MAIL_MAILER'       =>  config('mail.default'),
+            'MAIL_MAILER'       =>  env('MAIL_DRIVER', config('mail.default')),
         ]);
     }
 }

--- a/app/Listeners/Update/V20/Version207.php
+++ b/app/Listeners/Update/V20/Version207.php
@@ -26,7 +26,7 @@ class Version207 extends Listener
 
         // Update .env file
         Installer::updateEnv([
-            'MAIL_MAILER'       =>  env('MAIL_DRIVER'),
+            'MAIL_MAILER'       =>  config('mail.default'),
         ]);
     }
 }

--- a/app/Providers/App.php
+++ b/app/Providers/App.php
@@ -31,11 +31,11 @@ class App extends Provider
      */
     public function register()
     {
-        if (env('APP_INSTALLED') && env('APP_DEBUG')) {
+        if (config('app.installed') && config('app.debug')) {
             $this->app->register(\Barryvdh\Debugbar\ServiceProvider::class);
         }
 
-        if (env('APP_ENV') !== 'production') {
+        if (config('app.env') !== 'production') {
             $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
         }
     }

--- a/app/Traits/DateTime.php
+++ b/app/Traits/DateTime.php
@@ -17,7 +17,7 @@ trait DateTime
         $default = 'd M Y';
 
         // Make sure it's installed
-        if (!env('APP_INSTALLED') && (env('APP_ENV') !== 'testing')) {
+        if (!config('app.installed') && (config('app.env') !== 'testing')) {
             return $default;
         }
 

--- a/app/Utilities/Info.php
+++ b/app/Utilities/Info.php
@@ -33,7 +33,7 @@ class Info
 
     public static function mysqlVersion()
     {
-        if (env('DB_CONNECTION') === 'mysql') {
+        if (config('database.default') === 'mysql') {
             return DB::selectOne('select version() as mversion')->mversion;
         }
 

--- a/app/Utilities/Installer.php
+++ b/app/Utilities/Installer.php
@@ -183,8 +183,8 @@ class Installer
             'database'  => $database,
             'username'  => $username,
             'password'  => $password,
-            'driver'    => env('DB_CONNECTION', 'mysql'),
-            'charset'   => env('DB_CHARSET', 'utf8mb4'),
+            'driver'    => $connection = config('database.default', 'mysql'),
+            'charset'   => config("database.connections.$connection.charset", 'utf8mb4'),
         ]);
 
         try {
@@ -213,7 +213,7 @@ class Installer
             'DB_PREFIX'     =>  $prefix,
         ]);
 
-        $con = env('DB_CONNECTION', 'mysql');
+        $con = config('database.default', 'mysql');
 
         // Change current connection
         $db = Config::get('database.connections.' . $con);

--- a/app/Utilities/Installer.php
+++ b/app/Utilities/Installer.php
@@ -309,6 +309,8 @@ class Installer
 
         file_put_contents(base_path('.env'), $env);
 
+        Artisan::call('config:cache');
+
         return true;
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -14,6 +14,10 @@ return [
 
     'name' => env('APP_NAME', 'Akaunting'),
 
+    'installed' => env('APP_INSTALLED', false),
+
+    'schedule_time' => env('APP_SCHEDULE_TIME', '9:00'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Environment

--- a/resources/views/partials/admin/head.blade.php
+++ b/resources/views/partials/admin/head.blade.php
@@ -33,7 +33,7 @@
 
     <script type="text/javascript"><!--
         var url = '{{ url("/") }}';
-        var app_url = '{{ env("APP_URL") }}';
+        var app_url = '{{ config("app.url") }}';
     //--></script>
 
     @stack('js')

--- a/resources/views/partials/auth/head.blade.php
+++ b/resources/views/partials/auth/head.blade.php
@@ -28,7 +28,7 @@
 
     <script type="text/javascript"><!--
         var url = '{{ url("/") }}';
-        var app_url = '{{ env("APP_URL") }}';
+        var app_url = '{{ config("app.url") }}';
     //--></script>
 
     @stack('js')

--- a/resources/views/partials/modules/head.blade.php
+++ b/resources/views/partials/modules/head.blade.php
@@ -31,7 +31,7 @@
     <script type="text/javascript"><!--
         var url = '{{ url("/") }}';
         var app_home = '{{ url("apps/categories") }}';
-        var app_url = '{{ env("APP_URL") }}';
+        var app_url = '{{ config("app.url") }}';
     //--></script>
 
     @stack('js')

--- a/resources/views/partials/portal/head.blade.php
+++ b/resources/views/partials/portal/head.blade.php
@@ -30,7 +30,7 @@
 
     <script type="text/javascript"><!--
         var url = '{{ url("/") }}';
-        var app_url = '{{ env("APP_URL") }}';
+        var app_url = '{{ config("app.url") }}';
     //--></script>
 
     @stack('js')

--- a/resources/views/partials/signed/head.blade.php
+++ b/resources/views/partials/signed/head.blade.php
@@ -30,7 +30,7 @@
 
     <script type="text/javascript"><!--
         var url = '{{ url("/") }}';
-        var app_url = '{{ env("APP_URL") }}';
+        var app_url = '{{ config("app.url") }}';
     //--></script>
 
     @stack('js')

--- a/resources/views/partials/wizard/head.blade.php
+++ b/resources/views/partials/wizard/head.blade.php
@@ -30,7 +30,7 @@
 
     <script type="text/javascript"><!--
         var url = '{{ url("/") }}';
-        var app_url = '{{ env("APP_URL") }}';
+        var app_url = '{{ config("app.url") }}';
     //--></script>
 
     @stack('js')


### PR DESCRIPTION
Based on the warning in laravel's docs: [configuration-caching](https://laravel.com/docs/7.x/configuration#configuration-caching)

This PR simply replaces calls to env() with config(), allowing the configuration to be cached, improving app performance.

Also, added a call to 'artisan config:cache' after calling Installer::updateEnv.