### PR TITLE
Updated default start date to have a 1 day and month.  

### DIFF
--- a/app/Http/Controllers/Banking/Reconciliations.php
+++ b/app/Http/Controllers/Banking/Reconciliations.php
@@ -46,7 +46,7 @@ class Reconciliations extends Controller
         $accounts = Account::enabled()->pluck('name', 'id');
 
         $account_id = request('account_id', setting('general.default_account'));
-        $started_at = request('started_at', '0000-00-00');
+        $started_at = request('started_at', '0000-01-01');
         $ended_at = request('ended_at', '0000-00-00');
 
         $account = Account::find($account_id);


### PR DESCRIPTION
0 is not a valid day or a month.
Using 0000-00-00 with MySQL 8.0.20 causes error SQLSTATE[HY000]: General error: 1525 Incorrect DATE value