### PR TITLE
FIX install.stub

### DIFF
--- a/app/Console/Stubs/Modules/listeners/install.stub
+++ b/app/Console/Stubs/Modules/listeners/install.stub
@@ -5,7 +5,7 @@ namespace $MODULE_NAMESPACE$\$STUDLY_NAME$\Listeners;
 use App\Events\Module\Installed as Event;
 use App\Traits\Permissions;
 
-class FinishInstallation
+class InstallModule
 {
     use Permissions;
 


### PR DESCRIPTION
This PR resolves the issue after execute 

php artisan module:make my-module
php artisan module:install <company>

"Cannot declare class Modules\XXXX\Listeners\FinishInstallation, because the name is already in use"