### PR TITLE
Added support for db prefix in command line installer

### DIFF
--- a/app/Console/Commands/Install.php
+++ b/app/Console/Commands/Install.php
@@ -15,6 +15,7 @@ class Install extends Command
     const OPT_DB_NAME = 'db-name';
     const OPT_DB_USERNAME = 'db-username';
     const OPT_DB_PASSWORD = 'db-password';
+    const OPT_DB_PREFIX = 'db-prefix';
     const OPT_COMPANY_NAME = 'company-name';
     const OPT_COMPANY_EMAIL = 'company-email';
     const OPT_ADMIN_EMAIL = 'admin-email';
@@ -33,6 +34,7 @@ class Install extends Command
                             {--db-name= : Name of the database}
                             {--db-username=root : Username to use to access the database}
                             {--db-password= : Password to use to access the database}
+                            {--db-prefix= : Table name prefix}
                             {--company-name=My Company : Name of the company}
                             {--company-email=my@company.com : Email of the company}
                             {--admin-email= : Admin user email}
@@ -102,10 +104,11 @@ class Install extends Command
             'OPT_DB_NAME',
             'OPT_DB_USERNAME',
             'OPT_DB_PASSWORD',
+            'OPT_DB_PREFIX',
             'OPT_COMPANY_NAME',
             'OPT_COMPANY_EMAIL',
             'OPT_ADMIN_EMAIL',
-            'OPT_ADMIN_PASSWORD',
+            'OPT_ADMIN_PASSWORD'
         ];
 
         foreach ($contants as $const) {
@@ -177,10 +180,11 @@ class Install extends Command
         $this->db_name     = $this->option(self::OPT_DB_NAME);
         $this->db_username = $this->option(self::OPT_DB_USERNAME);
         $this->db_password = $this->option(self::OPT_DB_PASSWORD);
+        $this->db_prefix   = $this->option(self::OPT_DB_PREFIX);
 
         $this->line('Connecting to database ' . $this->db_name . '@' . $this->db_host . ':' . $this->db_port);
 
-        if (!Installer::createDbTables($this->db_host, $this->db_port, $this->db_name, $this->db_username, $this->db_password)) {
+        if (!Installer::createDbTables($this->db_host, $this->db_port, $this->db_name, $this->db_username, $this->db_password, $this->db_prefix)) {
             $this->error('Error: Could not connect to the database! Please, make sure the details are correct.');
 
             return false;

--- a/app/Utilities/Installer.php
+++ b/app/Utilities/Installer.php
@@ -141,14 +141,14 @@ class Installer
         ]);
 	}
 
-    public static function createDbTables($host, $port, $database, $username, $password)
+    public static function createDbTables($host, $port, $database, $username, $password, $prefix = null)
     {
         if (!static::isDbValid($host, $port, $database, $username, $password)) {
             return false;
         }
 
         // Set database details
-        static::saveDbVariables($host, $port, $database, $username, $password);
+        static::saveDbVariables($host, $port, $database, $username, $password, $prefix);
 
         // Try to increase the maximum execution time
         set_time_limit(300); // 5 minutes
@@ -199,9 +199,11 @@ class Installer
         return true;
     }
 
-    public static function saveDbVariables($host, $port, $database, $username, $password)
+    public static function saveDbVariables($host, $port, $database, $username, $password, $prefix = null)
     {
-        $prefix = strtolower(Str::random(3) . '_');
+        if (is_null($prefix)){
+            $prefix = strtolower(Str::random(3) . '_');
+        }
 
         // Update .env file
         static::updateEnv([


### PR DESCRIPTION
During installation from the command prompt, its pretty annoying we don't have a flag to control randomly generated database prefix. IMO prefix itself is not a good idea. Making a random prefix during the installation is even worrisome. Hence i've made few non-breaking changes to control prefixing during the installation via command line, added the flag `--db-prefix`. 

1. For those who don't want any prefix, `--db-prefix=""`.
2. For those who don't bother about the prefix, just ignore the flag, it'll do the random thing.
3. For those who want a proper prefix, `--db-prefix=my_prefix_`
