### PR TITLE
allow using own already selected checkbox values

### DIFF
--- a/app/Providers/Form.php
+++ b/app/Providers/Form.php
@@ -88,7 +88,7 @@ class Form extends Provider
         ]);
 
         Facade::component('checkboxGroup', 'partials.form.checkbox_group', [
-            'name', 'text', 'items' => [], 'value' => 'name', 'id' => 'id', 'attributes' => ['required' => 'required'], 'col' => 'col-md-12',
+            'name', 'text', 'items' => [], 'value' => 'name', 'id' => 'id', 'selected'=>[], 'attributes' => ['required' => 'required'], 'col' => 'col-md-12',
         ]);
 
         Facade::component('fileGroup', 'partials.form.file_group', [

--- a/resources/views/partials/form/checkbox_group.blade.php
+++ b/resources/views/partials/form/checkbox_group.blade.php
@@ -11,7 +11,7 @@
             @foreach($items as $item)
                 <div class="col-md-3">
                     <div class="custom-control custom-checkbox">
-                        {{ Form::checkbox($name, $item->$id, null, [
+                        {{ Form::checkbox($name, $item->$id, (is_array($selected) && count($selected) ? (in_array($item->$id, $selected) ? true : false) : null), [
                             'id' => 'checkbox-' . $name . '-' . $item->$id,
                             'class' => 'custom-control-input',
                             'v-model' => !empty($attributes['v-model']) ? $attributes['v-model'] : (!empty($attributes['data-field']) ? 'form.' . $attributes['data-field'] . '.'. $name : 'form.' . $name),


### PR DESCRIPTION
currently the checkbox partial blade does not allow you set own selected values, which prevents some dynamic options based on wheat you intend to work on.

this pull request is backward compatible with every play where the checkboxGroup macro is used