### PR TITLE
Fixes loading app documentation

### DIFF
--- a/app/Traits/Modules.php
+++ b/app/Traits/Modules.php
@@ -59,7 +59,7 @@ trait Modules
         return $item;
     }
 
-    public function getDocumentation($alias)
+    public function getDocumentation($alias, $data = [])
     {
         $key = 'apps.' . $alias . '.docs.' . $this->getDataKey($data);
 


### PR DESCRIPTION
This fixes a fatal error when trying to load an app's documentation from the app details page: 

![image](https://user-images.githubusercontent.com/171715/87246357-b2986580-c46e-11ea-8e04-c71532f06b67.png)
