### PR TITLE
Removes duplicate key from BillItem FormRequest

### DIFF
--- a/app/Http/Requests/Purchase/BillItem.php
+++ b/app/Http/Requests/Purchase/BillItem.php
@@ -28,7 +28,6 @@ class BillItem extends FormRequest
             'name' => 'required|string',
             'quantity' => 'required|integer',
             'price' => 'required',
-            'price' => 'required',
             'total' => 'required',
             'tax' => 'required',
             'tax_id' => 'required',


### PR DESCRIPTION
This removes a duplicate key in request validation of `app/Http/Requests/Purchase/BillItem.php` 