### PR TITLE
Made items, Purchases and Sales searchable #1346

### DIFF
--- a/app/Http/Controllers/Common/Items.php
+++ b/app/Http/Controllers/Common/Items.php
@@ -15,7 +15,9 @@ use App\Models\Common\Item;
 use App\Models\Setting\Category;
 use App\Models\Setting\Currency;
 use App\Models\Setting\Tax;
+use App\Services\Search\Common\ItemCollector;
 use App\Traits\Uploads;
+use Illuminate\Http\JsonResponse;
 
 class Items extends Controller
 {
@@ -402,5 +404,13 @@ class Items extends Controller
         $json->symbol = $currency->symbol;
 
         return response()->json($json);
+    }
+
+    public function search(): JsonResponse
+    {
+        $collector = new ItemCollector();
+        $results = $collector->collectByKeyword(request('keyword', ''));
+
+        return new JsonResponse($results);
     }
 }

--- a/app/Http/Controllers/Purchases/Bills.php
+++ b/app/Http/Controllers/Purchases/Bills.php
@@ -20,11 +20,13 @@ use App\Models\Purchase\Bill;
 use App\Models\Setting\Category;
 use App\Models\Setting\Currency;
 use App\Models\Setting\Tax;
+use App\Services\Search\Purchases\BillCollector;
 use App\Traits\Currencies;
 use App\Traits\DateTime;
 use App\Traits\Purchases;
 use App\Traits\Uploads;
 use App\Utilities\Modules;
+use Illuminate\Http\JsonResponse;
 
 class Bills extends Controller
 {
@@ -424,5 +426,13 @@ class Bills extends Controller
         $bill->template_path = 'purchases.bills.print';
 
         return $bill;
+    }
+
+    public function search(): JsonResponse
+    {
+        $collector = new BillCollector();
+        $results = $collector->collectByKeyword(request('keyword', ''));
+
+        return new JsonResponse($results);
     }
 }

--- a/app/Http/Controllers/Purchases/Payments.php
+++ b/app/Http/Controllers/Purchases/Payments.php
@@ -15,9 +15,11 @@ use App\Models\Banking\Transaction;
 use App\Models\Common\Contact;
 use App\Models\Setting\Category;
 use App\Models\Setting\Currency;
+use App\Services\Search\Purchases\PaymentCollector;
 use App\Traits\Currencies;
 use App\Traits\DateTime;
 use App\Utilities\Modules;
+use Illuminate\Http\JsonResponse;
 
 class Payments extends Controller
 {
@@ -228,5 +230,13 @@ class Payments extends Controller
     public function export()
     {
         return \Excel::download(new Export(), \Str::filename(trans_choice('general.payments', 2)) . '.xlsx');
+    }
+
+    public function search(): JsonResponse
+    {
+        $collector = new PaymentCollector();
+        $results = $collector->collectByKeyword(request('keyword', ''));
+
+        return new JsonResponse($results);
     }
 }

--- a/app/Http/Controllers/Purchases/Vendors.php
+++ b/app/Http/Controllers/Purchases/Vendors.php
@@ -14,8 +14,10 @@ use App\Models\Banking\Transaction;
 use App\Models\Common\Contact;
 use App\Models\Purchase\Bill;
 use App\Models\Setting\Currency;
+use App\Services\Search\Purchases\VendorCollector;
 use App\Traits\Contacts;
 use Date;
+use Illuminate\Http\JsonResponse;
 
 class Vendors extends Controller
 {
@@ -315,5 +317,13 @@ class Vendors extends Controller
         $vendor->symbol = $currency->symbol;
 
         return response()->json($vendor);
+    }
+
+    public function search(): JsonResponse
+    {
+        $collector = new VendorCollector();
+        $results = $collector->collectByKeyword(request('keyword', ''));
+
+        return new JsonResponse($results);
     }
 }

--- a/app/Http/Controllers/Sales/Customers.php
+++ b/app/Http/Controllers/Sales/Customers.php
@@ -14,7 +14,9 @@ use App\Models\Banking\Transaction;
 use App\Models\Common\Contact;
 use App\Models\Sale\Invoice;
 use App\Models\Setting\Currency;
+use App\Services\Search\Sales\CustomerSearchCollector;
 use Date;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request as BaseRequest;
 
 class Customers extends Controller
@@ -337,5 +339,13 @@ class Customers extends Controller
         ];
 
         return response()->json($json);
+    }
+
+    public function search(): JsonResponse
+    {
+        $collector = new CustomerSearchCollector();
+        $results = $collector->collectByKeyword(request('keyword', ''));
+
+        return new JsonResponse($results);
     }
 }

--- a/app/Http/Controllers/Sales/Invoices.php
+++ b/app/Http/Controllers/Sales/Invoices.php
@@ -20,11 +20,13 @@ use App\Models\Setting\Category;
 use App\Models\Setting\Currency;
 use App\Models\Setting\Tax;
 use App\Notifications\Sale\Invoice as Notification;
+use App\Services\Search\Sales\InvoiceSearchCollector;
 use App\Traits\Currencies;
 use App\Traits\DateTime;
 use App\Traits\Sales;
 use App\Utilities\Modules;
 use File;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\URL;
 
 class Invoices extends Controller
@@ -479,5 +481,13 @@ class Invoices extends Controller
         event(new \App\Events\Sale\InvoicePrinting($invoice));
 
         return $invoice;
+    }
+
+    public function search(): JsonResponse
+    {
+        $collector = new InvoiceSearchCollector();
+        $results = $collector->collectByKeyword(request('keyword', ''));
+
+        return new JsonResponse($results);
     }
 }

--- a/app/Http/Controllers/Sales/Revenues.php
+++ b/app/Http/Controllers/Sales/Revenues.php
@@ -15,9 +15,11 @@ use App\Models\Banking\Transaction;
 use App\Models\Common\Contact;
 use App\Models\Setting\Category;
 use App\Models\Setting\Currency;
+use App\Services\Search\Sales\RevenueSearchCollector;
 use App\Traits\Currencies;
 use App\Traits\DateTime;
 use App\Utilities\Modules;
+use Illuminate\Http\JsonResponse;
 
 class Revenues extends Controller
 {
@@ -228,5 +230,13 @@ class Revenues extends Controller
     public function export()
     {
         return \Excel::download(new Export(), \Str::filename(trans_choice('general.revenues', 2)) . '.xlsx');
+    }
+
+    public function search(): JsonResponse
+    {
+        $collector = new RevenueSearchCollector();
+        $results = $collector->collectByKeyword(request('keyword', ''));
+
+        return new JsonResponse($results);
     }
 }

--- a/app/Services/Search/Common/ItemCollector.php
+++ b/app/Services/Search/Common/ItemCollector.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services\Search\Common;
+
+use App\Models\Common\Item;
+use App\Services\Search\SearchCollectorInterface;
+
+class ItemCollector implements SearchCollectorInterface
+{
+    private const COLOR = '#efad32';
+
+    public function collectByKeyword(string $keyword): array
+    {
+        $items = Item::enabled()
+            ->usingSearchString($keyword)
+            ->get();
+
+        return array_map(static function (Item $item) {
+            return [
+                'id' => $item->id,
+                'name' => $item->name,
+                'type' => trans_choice('general.items', 1),
+                'color' => self::COLOR,
+                'href' => route('items.edit', $item->id),
+            ];
+        }, iterator_to_array($items));
+    }
+}
+

--- a/app/Services/Search/Purchases/BillCollector.php
+++ b/app/Services/Search/Purchases/BillCollector.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services\Search\Purchases;
+
+use App\Models\Purchase\Bill;
+use App\Services\Search\SearchCollectorInterface;
+
+class BillCollector implements SearchCollectorInterface
+{
+    private const COLOR = '#ef3232';
+
+    public function collectByKeyword(string $keyword): array
+    {
+        $bills = Bill::usingSearchString($keyword)->get();
+
+        return array_map(static function (Bill $bill) {
+            return [
+                'id'    => $bill->id,
+                'name'  => $bill->bill_number . ' - ' . $bill->contact_name,
+                'type'  => trans_choice('general.bills', 1),
+                'color' => self::COLOR,
+                'href'  => route('bills.show', $bill->id),
+            ];
+        }, iterator_to_array($bills));
+    }
+}

--- a/app/Services/Search/Purchases/PaymentCollector.php
+++ b/app/Services/Search/Purchases/PaymentCollector.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services\Search\Purchases;
+
+use App\Models\Banking\Transaction;
+use App\Services\Search\SearchCollectorInterface;
+
+class PaymentCollector implements SearchCollectorInterface
+{
+    private const COLOR = '#ef3232';
+
+    public function collectByKeyword(string $keyword): array
+    {
+        $payments = Transaction::expense()
+            ->usingSearchString($keyword)
+            ->get();
+
+        return array_map(static function (Transaction $transaction) {
+            $contact = $transaction->contact()->get()->first()->name;
+
+            $label = sprintf(
+                '%s - %s - %s',
+                $transaction->paid_at,
+                $contact,
+                money($transaction->getAmount(), $transaction->currency_code, true)
+            );
+
+            return [
+                'id' => $transaction->id,
+                'name' => $label,
+                'type' => trans_choice('general.payments', 1),
+                'color' => self::COLOR,
+                'href' => route('payments.edit', $transaction->id)
+            ];
+        }, iterator_to_array($payments));
+    }
+}

--- a/app/Services/Search/Purchases/VendorCollector.php
+++ b/app/Services/Search/Purchases/VendorCollector.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services\Search\Purchases;
+
+use App\Models\Common\Contact;
+use App\Services\Search\SearchCollectorInterface;
+
+class VendorCollector implements SearchCollectorInterface
+{
+    private const COLOR = '#efef32';
+
+    public function collectByKeyword(string $keyword): array
+    {
+        $vendors = Contact::vendor()
+            ->enabled()
+            ->usingSearchString($keyword)
+            ->get();
+
+        return array_map(static function (Contact $vendor) {
+            return [
+                'id' => $vendor->id,
+                'name' => $vendor->name,
+                'type' => trans_choice('general.vendors', 1),
+                'color' => self::COLOR,
+                'href' => route('vendors.show', $vendor->id)
+            ];
+        }, iterator_to_array($vendors));
+    }
+}

--- a/app/Services/Search/Sales/CustomerSearchCollector.php
+++ b/app/Services/Search/Sales/CustomerSearchCollector.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Services\Search\Sales;
+
+use App\Models\Common\Contact;
+use App\Services\Search\SearchCollectorInterface;
+
+class CustomerSearchCollector implements SearchCollectorInterface
+{
+    private const COLOR = '#328aef';
+
+    public function collectByKeyword(string $keyword): array
+    {
+        $contacts = Contact::customer()
+            ->enabled()
+            ->usingSearchString($keyword)
+            ->get();
+
+        return array_map(static function (Contact $contact) {
+            return [
+                'id' => $contact->id,
+                'name' => $contact->name,
+                'type' => trans_choice('general.customers', 1),
+                'color' => self::COLOR,
+                'href' => route('customers.show', $contact->id)
+            ];
+        }, iterator_to_array($contacts));
+    }
+}

--- a/app/Services/Search/Sales/InvoiceSearchCollector.php
+++ b/app/Services/Search/Sales/InvoiceSearchCollector.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services\Search\Sales;
+
+use App\Models\Sale\Invoice;
+use App\Services\Search\SearchCollectorInterface;
+
+class InvoiceSearchCollector implements SearchCollectorInterface
+{
+    private const COLOR = '#6da252';
+
+    public function collectByKeyword(string $keyword): array
+    {
+        $invoices = Invoice::usingSearchString($keyword)->get();
+
+        return array_map(static function (Invoice $invoice) {
+            $label = sprintf(
+                '%s - %s',
+                $invoice->invoice_number,
+                $invoice->contact_name
+            );
+
+            return [
+                'id' => $invoice->id,
+                'name' => $label,
+                'type' => trans_choice('general.invoices', 1),
+                'color' => self::COLOR,
+                'href' => route('invoices.show', $invoice->id)
+            ];
+        }, iterator_to_array($invoices));
+    }
+}

--- a/app/Services/Search/Sales/RevenueSearchCollector.php
+++ b/app/Services/Search/Sales/RevenueSearchCollector.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Services\Search\Sales;
+
+use App\Models\Banking\Transaction;
+use App\Services\Search\SearchCollectorInterface;
+
+class RevenueSearchCollector implements SearchCollectorInterface
+{
+    private const COLOR = '#00c0ef';
+
+    public function collectByKeyword(string $keyword): array
+    {
+        $transactions = Transaction::income()
+            ->usingSearchString($keyword)
+            ->get();
+
+        return array_map(static function (Transaction $transaction) {
+            $contact = $transaction->contact()->get()->first()->name;
+
+            $label = sprintf(
+                '%s - %s - %s',
+                $transaction->paid_at,
+                $contact,
+                money($transaction->getAmount(), $transaction->currency_code, true)
+            );
+
+            return [
+                'id' => $transaction->id,
+                'name' => $label,
+                'type' => trans_choice('general.revenues', 1),
+                'color' => self::COLOR,
+                'href' => route('revenues.edit', $transaction->id)
+             ];
+        }, iterator_to_array($transactions));
+    }
+}

--- a/app/Services/Search/SearchCollectorInterface.php
+++ b/app/Services/Search/SearchCollectorInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Services\Search;
+
+interface SearchCollectorInterface
+{
+    public function collectByKeyword(string $keyword): array;
+}

--- a/resources/assets/js/components/AkauntingSearch.vue
+++ b/resources/assets/js/components/AkauntingSearch.vue
@@ -35,9 +35,9 @@
         </template>
 
         <el-option v-if="!group" v-for="option in selectOptions"
-            :key="option.id"
-            :label="option.name"
-            :value="option.id">
+                   :key="option.id"
+                   :label="option.name"
+                   :value="option.id">
         </el-option>
 
         <el-option-group
@@ -63,7 +63,7 @@
 </style>
 
 <script>
-    import { Select, Option, OptionGroup } from 'element-ui';
+    import {Select, Option, OptionGroup} from 'element-ui';
 
     export default {
         name: 'akaunting-select',
@@ -97,7 +97,7 @@
                 description: "Prepend icon (left)"
             },
 
-            group:  {
+            group: {
                 type: Boolean,
                 default: false,
                 description: "Selectbox option group status"
@@ -129,6 +129,11 @@
                 default: 'invoice',
                 description: "Ger remote item type."
             },
+            route: {
+                type: String,
+                default: '',
+                description: 'Search endpoint'
+            }
         },
 
         data() {
@@ -156,12 +161,31 @@
                         this.$emit('label', item.name);
                         this.$emit('option', item);
 
+                        window.location = item.href;
                         return;
                     }
                 });
             },
-            remoteMethod() {
+            remoteMethod(query) {
+                if (this.route.length < 1) {
+                    return;
+                }
 
+                this.loading = true;
+                axios.post(this.route, {
+                    keyword: query
+                }).then(response => {
+                    this.loading = false;
+                    this.selectOptions = response.data;
+                }).catch(error => {
+                    this.loading = false;
+                    this.$notify({
+                        message: 'We couldn\'t process your request right now. Please try again later.',
+                        timeout: 5000,
+                        icon: 'fas fa-bell',
+                        type: 'warning'
+                    });
+                });
             },
         },
 

--- a/resources/views/common/items/index.blade.php
+++ b/resources/views/common/items/index.blade.php
@@ -24,6 +24,7 @@
                         <akaunting-search
                             :placeholder="'{{ trans('general.search_placeholder') }}'"
                             :options="{{ json_encode([]) }}"
+                            :route="'{{route('items.search')}}'"
                         ></akaunting-search>
                     </div>
 

--- a/resources/views/purchases/bills/index.blade.php
+++ b/resources/views/purchases/bills/index.blade.php
@@ -24,6 +24,7 @@
                         <akaunting-search
                             :placeholder="'{{ trans('general.search_placeholder') }}'"
                             :options="{{ json_encode([]) }}"
+                            :route="'{{ route('bills.search') }}'"
                         ></akaunting-search>
                     </div>
 

--- a/resources/views/purchases/payments/index.blade.php
+++ b/resources/views/purchases/payments/index.blade.php
@@ -24,6 +24,7 @@
                         <akaunting-search
                             :placeholder="'{{ trans('general.search_placeholder') }}'"
                             :options="{{ json_encode([]) }}"
+                            :route="'{{ route('payments.search') }}'"
                         ></akaunting-search>
                     </div>
 

--- a/resources/views/purchases/vendors/index.blade.php
+++ b/resources/views/purchases/vendors/index.blade.php
@@ -24,6 +24,7 @@
                         <akaunting-search
                             :placeholder="'{{ trans('general.search_placeholder') }}'"
                             :options="{{ json_encode([]) }}"
+                            :route="'{{ route('vendors.search') }}'"
                         ></akaunting-search>
                     </div>
 

--- a/resources/views/sales/customers/index.blade.php
+++ b/resources/views/sales/customers/index.blade.php
@@ -24,6 +24,7 @@
                         <akaunting-search
                             :placeholder="'{{ trans('general.search_placeholder') }}'"
                             :options="{{ json_encode([]) }}"
+                            :route="'{{ route('customers.search') }}'"
                         ></akaunting-search>
                     </div>
 

--- a/resources/views/sales/invoices/index.blade.php
+++ b/resources/views/sales/invoices/index.blade.php
@@ -24,6 +24,7 @@
                         <akaunting-search
                             :placeholder="'{{ trans('general.search_placeholder') }}'"
                             :options="{{ json_encode([]) }}"
+                            :route="'{{ route('invoices.search') }}'"
                         ></akaunting-search>
                     </div>
 

--- a/resources/views/sales/revenues/index.blade.php
+++ b/resources/views/sales/revenues/index.blade.php
@@ -24,6 +24,7 @@
                         <akaunting-search
                             :placeholder="'{{ trans('general.search_placeholder') }}'"
                             :options="{{ json_encode([]) }}"
+                            :route="'{{ route('revenues.search') }}'"
                         ></akaunting-search>
                     </div>
 

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -34,6 +34,7 @@ Route::group(['prefix' => 'common'], function () {
     Route::post('items/total', 'Common\Items@total')->middleware(['money'])->name('items.total');
     Route::get('items/{item}/duplicate', 'Common\Items@duplicate')->name('items.duplicate');
     Route::post('items/import', 'Common\Items@import')->name('items.import');
+    Route::post('items/search', 'Common\Items@search')->name('items.search');
     Route::get('items/export', 'Common\Items@export')->name('items.export');
     Route::get('items/{item}/enable', 'Common\Items@enable')->name('items.enable');
     Route::get('items/{item}/disable', 'Common\Items@disable')->name('items.disable');
@@ -78,11 +79,13 @@ Route::group(['prefix' => 'sales'], function () {
     Route::get('invoices/{invoice}/duplicate', 'Sales\Invoices@duplicate')->name('invoices.duplicate');
     Route::get('invoices/addItem', 'Sales\Invoices@addItem')->middleware(['money'])->name('invoice.add.item');
     Route::post('invoices/import', 'Sales\Invoices@import')->name('invoices.import');
+    Route::post('invoices/search', 'Sales\Invoices@search')->name('invoices.search');
     Route::get('invoices/export', 'Sales\Invoices@export')->name('invoices.export');
     Route::resource('invoices', 'Sales\Invoices', ['middleware' => ['date.format', 'money']]);
 
     Route::get('revenues/{revenue}/duplicate', 'Sales\Revenues@duplicate')->name('revenues.duplicate');
     Route::post('revenues/import', 'Sales\Revenues@import')->name('revenues.import');
+    Route::post('revenues/search', 'Sales\Revenues@search')->name('revenues.search');
     Route::get('revenues/export', 'Sales\Revenues@export')->name('revenues.export');
     Route::resource('revenues', 'Sales\Revenues', ['middleware' => ['date.format', 'money']]);
 
@@ -90,6 +93,7 @@ Route::group(['prefix' => 'sales'], function () {
     Route::get('customers/{customer}/duplicate', 'Sales\Customers@duplicate')->name('customers.duplicate');
     Route::post('customers/field', 'Sales\Customers@field')->name('customers.field');
     Route::post('customers/import', 'Sales\Customers@import')->name('customers.import');
+    Route::post('customers/search', 'Sales\Customers@search')->name('customers.search');
     Route::get('customers/export', 'Sales\Customers@export')->name('customers.export');
     Route::get('customers/{customer}/enable', 'Sales\Customers@enable')->name('customers.enable');
     Route::get('customers/{customer}/disable', 'Sales\Customers@disable')->name('customers.disable');
@@ -106,17 +110,20 @@ Route::group(['prefix' => 'purchases'], function () {
     Route::get('bills/{bill}/duplicate', 'Purchases\Bills@duplicate')->name('bills.duplicate');
     Route::get('bills/addItem', 'Purchases\Bills@addItem')->middleware(['money'])->name('bill.add.item');
     Route::post('bills/import', 'Purchases\Bills@import')->name('bills.import');
+    Route::post('bills/search', 'Purchases\Bills@search')->name('bills.search');
     Route::get('bills/export', 'Purchases\Bills@export')->name('bills.export');
     Route::resource('bills', 'Purchases\Bills', ['middleware' => ['date.format', 'money']]);
 
     Route::get('payments/{payment}/duplicate', 'Purchases\Payments@duplicate')->name('payments.duplicate');
     Route::post('payments/import', 'Purchases\Payments@import')->name('payments.import');
+    Route::post('payments/search', 'Purchases\Payments@search')->name('payments.search');
     Route::get('payments/export', 'Purchases\Payments@export')->name('payments.export');
     Route::resource('payments', 'Purchases\Payments', ['middleware' => ['date.format', 'money']]);
 
     Route::get('vendors/currency', 'Purchases\Vendors@currency');
     Route::get('vendors/{vendor}/duplicate', 'Purchases\Vendors@duplicate')->name('vendors.duplicate');
     Route::post('vendors/import', 'Purchases\Vendors@import')->name('vendors.import');
+    Route::post('vendors/search', 'Purchases\Vendors@search')->name('vendors.search');
     Route::get('vendors/export', 'Purchases\Vendors@export')->name('vendors.export');
     Route::get('vendors/{vendor}/enable', 'Purchases\Vendors@enable')->name('vendors.enable');
     Route::get('vendors/{vendor}/currency', 'Purchases\Vendors@currency')->name('vendors.currency');


### PR DESCRIPTION
Hey

I've added search capabilities to the following pages:
* Items
* Bills
* Payments
* Vendors
* Customers
* Invoices
* Revenues

I've written 'SearchResultCollectors' as separate services in order to have thin controller and to make them reuse-able. Each provider implements the SearchCollecterInterface. In a later state we could tag the collecters with a service provider and inject them in the common/search controller (just a wild thought).

Functionality wise, when typing in the search bar it uses the function 'usingSearchString' in the backend. So you could actually search with: `date:2020` or something or with `paid_at:2020`. When selecting a search option you get redirected to the selected entities show or in some cases the edit page (revenue and payments).

Addresses issue #1346