### PR TITLE
fix accounts and transactions show route usage

### DIFF
--- a/app/Http/Controllers/Api/Banking/Accounts.php
+++ b/app/Http/Controllers/Api/Banking/Accounts.php
@@ -52,7 +52,7 @@ class Accounts extends ApiController
     {
         $account = $this->dispatch(new CreateAccount($request));
 
-        return $this->response->created(route('api.accounts.show', $account->id));
+        return $this->response->created(route('accounts.show', $account->id));
     }
 
     /**

--- a/app/Http/Controllers/Api/Banking/Transactions.php
+++ b/app/Http/Controllers/Api/Banking/Transactions.php
@@ -45,7 +45,7 @@ class Transactions extends ApiController
     {
         $transaction = $this->dispatch(new CreateTransaction($request));
 
-        return $this->response->created(route('api.transactions.show', $transaction->id));
+        return $this->response->created(route('transactions.show', $transaction->id));
     }
 
     /**

--- a/app/Http/Controllers/Api/Common/Contacts.php
+++ b/app/Http/Controllers/Api/Common/Contacts.php
@@ -67,7 +67,7 @@ class Contacts extends ApiController
     {
         $contact = $this->dispatch(new CreateContact($request));
 
-        return $this->response->created(route('api.contacts.show', $contact->id));
+        return $this->response->created(route('contacts.show', $contact->id));
     }
 
     /**

--- a/app/Http/Controllers/Api/Common/Items.php
+++ b/app/Http/Controllers/Api/Common/Items.php
@@ -50,7 +50,7 @@ class Items extends ApiController
     {
         $item = $this->dispatch(new CreateItem($request));
 
-        return $this->response->created(route('api.items.show', $item->id));
+        return $this->response->created(route('items.show', $item->id));
     }
 
     /**

--- a/app/Http/Controllers/Api/Sales/Invoices.php
+++ b/app/Http/Controllers/Api/Sales/Invoices.php
@@ -52,7 +52,7 @@ class Invoices extends ApiController
     {
         $invoice = $this->dispatch(new CreateInvoice($request));
 
-        return $this->response->created(route('api.invoices.show', $invoice->id));
+        return $this->response->created(route('invoices.show', $invoice->id));
     }
 
     /**


### PR DESCRIPTION
After adding new transactions via REST API, I received 500 error with message:
`Exception: {"message":"Route [api.transactions.show] not defined.","status_code":500, ... }`
So I fixed transaction route to resolve this issue.

It seems like all methods with `api...show` calls are broken, currently I'm fixed what I need for my project.