### PR TITLE
Fix duplicate stack for item name input in edit invoice view

### DIFF
--- a/resources/views/sales/invoices/item.blade.php
+++ b/resources/views/sales/invoices/item.blade.php
@@ -87,7 +87,7 @@
         <td class="border-right-0 border-bottom-0 pb-0"
             :class="[{'has-error': form.errors.has('items.' + index + '.price') }]">
             @stack('price_input_start')
-                {{ Form::moneyGroup('name', '', '', ['required' => 'required', 'v-model' => 'row.price', 'v-error' => 'form.errors.get(\'items.\' + index + \'.price\')', 'v-error-message' => 'form.errors.get(\'items.\' + index + \'.price\')' , 'data-item' => 'price', 'currency' => $currency, 'dynamic-currency' => 'currency', 'change' => 'row.price = $event; form.errors.clear(\'items.\' + index + \'.price\'); onCalculateTotal'], 0.00, 'text-right input-price') }}
+                {{ Form::moneyGroup('price', '', '', ['required' => 'required', 'v-model' => 'row.price', 'v-error' => 'form.errors.get(\'items.\' + index + \'.price\')', 'v-error-message' => 'form.errors.get(\'items.\' + index + \'.price\')' , 'data-item' => 'price', 'currency' => $currency, 'dynamic-currency' => 'currency', 'change' => 'row.price = $event; form.errors.clear(\'items.\' + index + \'.price\'); onCalculateTotal'], 0.00, 'text-right input-price') }}
 
                 <input :name="'items.' + index + '.currency'"
                     data-item="currency"


### PR DESCRIPTION
I wanted to add some custom html after the input for the item name in the edit invoice view. So I used the stack ```name_input_end```. But my custom html showed up after the name input AND after the price input. This is because the ```Form::moneyGroup``` generates a dynamic stack with the passed name argument. And the argument was set to ```name``` but I think it should be ```price```.