### PR TITLE
Fix icon of money inputs

### DIFF
--- a/resources/assets/js/components/AkauntingMoney.vue
+++ b/resources/assets/js/components/AkauntingMoney.vue
@@ -6,7 +6,7 @@
         <div class="input-group input-group-merge" :class="group_class">
             <div v-if="icon" class="input-group-prepend">
                 <span class="input-group-text">
-                    <i class="fa fa-" :class="icon"></i>
+                    <i :class="'fa fa-' + icon"></i>
                 </span>
             </div>
 


### PR DESCRIPTION
The icon of money inputs were not visible. This PR fixes the CSS class generation.

Old:

```class="fa fa- money-bill-alt"```

New:

```class="fa fa-money-bill-alt"```