### PR TITLE
Fix error when change account enabled status from account list

### DIFF
--- a/app/Jobs/Banking/UpdateAccount.php
+++ b/app/Jobs/Banking/UpdateAccount.php
@@ -52,22 +52,26 @@ class UpdateAccount extends Job
      */
     public function authorize()
     {
+        if ($this->request->has('enabled')) {
+            if (!$this->request->get('enabled') && ($this->account->id == setting('default.account'))) {
+                $relationships[] = strtolower(trans_choice('general.companies', 1));
+
+                $message = trans('messages.warning.disabled', ['name' => $this->account->name, 'text' => implode(', ', $relationships)]);
+
+                throw new \Exception($message);
+            }
+        }
+
         if (!$relationships = $this->getRelationships()) {
             return;
         }
 
-        if ($this->account->currency_code != $this->request->get('currency_code')) {
-            $message = trans('messages.warning.disable_code', ['name' => $this->account->name, 'text' => implode(', ', $relationships)]);
+        if ($this->request->has('currency_code')) {
+            if ($this->account->currency_code != $this->request->get('currency_code')) {
+                $message = trans('messages.warning.disable_code', ['name' => $this->account->name, 'text' => implode(', ', $relationships)]);
 
-            throw new \Exception($message);
-        }
-
-        if (!$this->request->get('enabled') && ($this->account->id == setting('default.account'))) {
-            $relationships[] = strtolower(trans_choice('general.companies', 1));
-
-            $message = trans('messages.warning.disabled', ['name' => $this->account->name, 'text' => implode(', ', $relationships)]);
-
-            throw new \Exception($message);
+                throw new \Exception($message);
+            }
         }
     }
 


### PR DESCRIPTION
It was not possible to change the account enabled status from the account list (error message: Warning: You are not allowed to disable or change the currency...). This is because the ```UpdateAccount``` job always checked the currency code for changes.

Furthermore it was possible to disable the company default account if there are no transactions. This PR fixes this also.