### PR TITLE
Fix transaction not visible when paid on the end date of a reconciliation

### DIFF
--- a/app/Http/Controllers/Banking/Reconciliations.php
+++ b/app/Http/Controllers/Banking/Reconciliations.php
@@ -177,10 +177,10 @@ class Reconciliations extends Controller
      */
     protected function getTransactions($account, $started_at, $ended_at)
     {
-        $started = explode(' ', $started_at);
-        $ended = explode(' ', $ended_at);
+        $started = explode(' ', $started_at)[0] . ' 00:00:00';
+        $ended = explode(' ', $ended_at)[0] . ' 23:59:59';
 
-        $transactions = Transaction::where('account_id', $account->id)->whereBetween('paid_at', [$started[0], $ended[0]])->get();
+        $transactions = Transaction::where('account_id', $account->id)->whereBetween('paid_at', [$started, $ended])->get();
 
         return collect($transactions)->sortByDesc('paid_at');
     }


### PR DESCRIPTION
When creating a reconciliation and a transaction was paid on the selected end date (Y-m-d) of the reconciliation and after the current time (H:i:s) then this transaction was not visible in the list. This PR sets ```23:59:59``` as the end time and all transactions paid on the end date will be loaded.