### PR TITLE
Leverage translation strings in the bulk actions modal.

### DIFF
--- a/resources/views/partials/form/bulk_action_row_group.blade.php
+++ b/resources/views/partials/form/bulk_action_row_group.blade.php
@@ -46,7 +46,7 @@
                             <option
                                 value="{{ $key }}"
                                 @if(!empty($action['message']))
-                                data-message="{{ trans_choice($action['message'], 2, ['type' => $text]) }}"
+                                data-message="{{ trans_choice($action['message'], 2, ['type' => strtolower(trans_choice($text, 2))]) }}"
                                 @endif
                                 @if(isset($action['path']) && !empty($action['path']))
                                     data-path="{{ route('bulk-actions.action', $action['path']) }}"


### PR DESCRIPTION
Though the `$text` can contain just a plain string, generally it is a translation string and should be used with the localization helper. Otherwise, the bulk actions modal will show a weird text instead of an item type, translated into the current locale. And actually, the `$text` variable is used with a localization helper in two places of the view:

![2021-01-01 17-36-01 Ubuntu Mate 19 10 (Снимок 162)  Работает  - Oracle VM VirtualBox   1](https://user-images.githubusercontent.com/7408605/103437988-1a7a7c80-4c58-11eb-8b47-4c71aa33b8b8.png)
