### PR TITLE
Fix some usages of translation strings.

### DIFF
--- a/app/Http/Controllers/Purchases/Bills.php
+++ b/app/Http/Controllers/Purchases/Bills.php
@@ -233,7 +233,7 @@ class Bills extends Controller
     {
         event(new \App\Events\Document\DocumentReceived($bill));
 
-        $message = trans('general.messages.marked_received', ['type' => trans_choice('general.bills', 1)]);
+        $message = trans('documents.messages.marked_received', ['type' => trans_choice('general.bills', 1)]);
 
         flash($message)->success();
 
@@ -251,7 +251,7 @@ class Bills extends Controller
     {
         event(new \App\Events\Document\DocumentCancelled($bill));
 
-        $message = trans('general.messages.marked_cancelled', ['type' => trans_choice('general.bills', 1)]);
+        $message = trans('documents.messages.marked_cancelled', ['type' => trans_choice('general.bills', 1)]);
 
         flash($message)->success();
 
@@ -310,7 +310,7 @@ class Bills extends Controller
         try {
             $this->dispatch(new CreateBankingDocumentTransaction($bill, ['type' => 'expense']));
 
-            $message = trans('general.messages.marked_paid', ['type' => trans_choice('general.bills', 1)]);
+            $message = trans('documents.messages.marked_paid', ['type' => trans_choice('general.bills', 1)]);
 
             flash($message)->success();
         } catch(\Exception $e) {

--- a/app/Http/Controllers/Sales/Invoices.php
+++ b/app/Http/Controllers/Sales/Invoices.php
@@ -251,7 +251,7 @@ class Invoices extends Controller
     {
         event(new \App\Events\Document\DocumentCancelled($invoice));
 
-        $message = trans('general.messages.marked_cancelled', ['type' => trans_choice('general.invoices', 1)]);
+        $message = trans('documents.messages.marked_cancelled', ['type' => trans_choice('general.invoices', 1)]);
 
         flash($message)->success();
 
@@ -360,7 +360,7 @@ class Invoices extends Controller
         try {
             event(new \App\Events\Document\PaymentReceived($invoice, ['type' => 'income']));
 
-            $message = trans('general.messages.marked_paid', ['type' => trans_choice('general.invoices', 1)]);
+            $message = trans('documents.messages.marked_paid', ['type' => trans_choice('general.invoices', 1)]);
 
             flash($message)->success();
         } catch(\Exception $e) {

--- a/app/Listeners/Document/MarkDocumentCancelled.php
+++ b/app/Listeners/Document/MarkDocumentCancelled.php
@@ -21,6 +21,6 @@ class MarkDocumentCancelled
     {
         $this->dispatch(new CancelDocument($event->document));
 
-        $this->dispatch(new CreateDocumentHistory($event->document, 0, trans('general.messages.marked_cancelled', ['type' => ''])));
+        $this->dispatch(new CreateDocumentHistory($event->document, 0, trans('documents.messages.marked_cancelled', ['type' => ''])));
     }
 }

--- a/app/Listeners/Document/MarkDocumentReceived.php
+++ b/app/Listeners/Document/MarkDocumentReceived.php
@@ -24,6 +24,6 @@ class MarkDocumentReceived
             $event->document->save();
         }
 
-        $this->dispatch(new CreateDocumentHistory($event->document, 0, trans('general.messages.marked_received', ['type' => ''])));
+        $this->dispatch(new CreateDocumentHistory($event->document, 0, trans('documents.messages.marked_received', ['type' => ''])));
     }
 }

--- a/app/Listeners/Document/MarkDocumentViewed.php
+++ b/app/Listeners/Document/MarkDocumentViewed.php
@@ -29,6 +29,6 @@ class MarkDocumentViewed
         $document->status = 'viewed';
         $document->save();
 
-        $this->dispatch(new CreateDocumentHistory($event->document, 0, trans('general.messages.marked_viewed', ['type' => ''])));
+        $this->dispatch(new CreateDocumentHistory($event->document, 0, trans('documents.messages.marked_viewed', ['type' => ''])));
     }
 }


### PR DESCRIPTION
There is no such node in translation strings as `general.messages`, but there are appropriate strings under the `documents.messages` node.