### PR TITLE
Fix a filter name in documents list.

### DIFF
--- a/resources/lang/en-GB/search_string.php
+++ b/resources/lang/en-GB/search_string.php
@@ -10,6 +10,7 @@ return [
         'billed_at'         => 'Bill Date',
         'due_at'            => 'Due Date',
         'invoiced_at'       => 'Invoice Date',
+        'issued_at'         => 'Issue Date',
     ],
 
 ];


### PR DESCRIPTION
Without a translation string the filter for the `issued_at` field is shown like this:

![2021-01-02 17-55-09 Ubuntu Mate 19 10 (Снимок 168)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/103457415-6517f980-4d29-11eb-8aac-83b38d77b6af.png)

After applying this fix the filter will be shown correctly, however, we'll need to find a way to name it correspondingly to the document type, but this is a completely different issue:

![2021-01-02 18-36-44 Ubuntu Mate 19 10 (Снимок 168)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/103457456-b1fbd000-4d29-11eb-933b-88fc9d201381.png)
