### PR TITLE
Fix showing a divider in the document actions menu.

### DIFF
--- a/resources/views/components/documents/index/card-body.blade.php
+++ b/resources/views/components/documents/index/card-body.blade.php
@@ -197,15 +197,13 @@
                                     @endif
                                     @stack('edit_button_end')
 
-                                    <div class="dropdown-divider"></div>
-
                                     @if ($checkButtonCancelled)
                                         @if ($item->status != 'cancelled')
                                             @stack('duplicate_button_start')
                                             @if (!$hideButtonDuplicate)
                                                 @can($permissionDocumentCreate)
-                                                    <a class="dropdown-item" href="{{ route($routeButtonDuplicate, $item->id) }}">{{ trans('general.duplicate') }}</a>
                                                     <div class="dropdown-divider"></div>
+                                                    <a class="dropdown-item" href="{{ route($routeButtonDuplicate, $item->id) }}">{{ trans('general.duplicate') }}</a>
                                                 @endcan
                                             @endif
                                             @stack('duplicate_button_end')
@@ -213,6 +211,7 @@
                                             @stack('cancel_button_start')
                                             @if (!$hideButtonCancel)
                                                 @can($permissionDocumentUpdate)
+                                                    <div class="dropdown-divider"></div>
                                                     <a class="dropdown-item" href="{{ route($routeButtonCancelled, $item->id) }}">{{ trans('general.cancel') }}</a>
                                                 @endcan
                                             @endif
@@ -222,8 +221,8 @@
                                         @stack('duplicate_button_start')
                                         @if (!$hideButtonDuplicate)
                                             @can($permissionDocumentCreate)
-                                                <a class="dropdown-item" href="{{ route($routeButtonDuplicate, $item->id) }}">{{ trans('general.duplicate') }}</a>
                                                 <div class="dropdown-divider"></div>
+                                                <a class="dropdown-item" href="{{ route($routeButtonDuplicate, $item->id) }}">{{ trans('general.duplicate') }}</a>
                                             @endcan
                                         @endif
                                         @stack('duplicate_button_end')
@@ -231,6 +230,7 @@
                                         @stack('cancel_button_start')
                                         @if (!$hideButtonCancel)
                                             @can($permissionDocumentUpdate)
+                                                <div class="dropdown-divider"></div>
                                                 <a class="dropdown-item" href="{{ route($routeButtonCancelled, $item->id) }}">{{ trans('general.cancel') }}</a>
                                             @endcan
                                         @endif


### PR DESCRIPTION
A divider in the document actions menu should be shown only if there are the following menu items. But now it is shown even when there are no other menu items:

![2021-01-02 19-00-27 Ubuntu Mate 19 10 (Снимок 168)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/103457923-76fb9b80-4d2d-11eb-92a9-4824c605770d.png)

This PR fixes such a behavior.