### PR TITLE
Use the provided value of the 'route-button-add-new' attribute in the document view

### DIFF
--- a/app/Abstracts/View/Components/DocumentShow.php
+++ b/app/Abstracts/View/Components/DocumentShow.php
@@ -660,6 +660,10 @@ abstract class DocumentShow extends Component
 
     protected function getRouteButtonAddNew($type, $routeButtonAddNew)
     {
+        if (!empty($routeButtonAddNew)) {
+            return $routeButtonAddNew;
+        }
+
         $page = Str::plural($type, 2);
 
         $route = $page . '.create';


### PR DESCRIPTION
Otherwise, it throws an exception even when the value of the attribute was provided:

![2021-01-03 14-42-15 Ubuntu Mate 19 10 (Снимок 171)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/103474847-fe024f80-4dd1-11eb-8a4b-f035e2c49556.png)
