### PR TITLE
Use more features of the delete modal dialog

### DIFF
--- a/app/Abstracts/View/Components/DocumentShow.php
+++ b/app/Abstracts/View/Components/DocumentShow.php
@@ -339,6 +339,9 @@ abstract class DocumentShow extends Component
 
     public $attachment;
 
+    /** @var string */
+    public $textDeleteModal;
+
     /**
      * Create a new component instance.
      *
@@ -366,7 +369,8 @@ abstract class DocumentShow extends Component
         bool $hideOrderNumber = false, bool $hideDocumentNumber = false, bool $hideIssuedAt = false, bool $hideDueAt = false,
         string $textContactInfo = '', string $textDocumentNumber = '', string $textOrderNumber = '', string $textIssuedAt = '', string $textDueAt = '',
         bool $hideItems = false, bool $hideName = false, bool $hideDescription = false, bool $hideQuantity = false, bool $hidePrice = false, bool $hideDiscount = false, bool $hideAmount = false, bool $hideNote = false, bool $hideAttachment = false,
-        string $textItems = '', string $textQuantity = '', string $textPrice = '', string $textAmount = '', $attachment = []
+        string $textItems = '', string $textQuantity = '', string $textPrice = '', string $textAmount = '', $attachment = [],
+        string $textDeleteModal = ''
     ) {
         $this->type = $type;
         $this->document = $document;
@@ -503,6 +507,8 @@ abstract class DocumentShow extends Component
         $this->textQuantity = $textQuantity;
         $this->textPrice = $textPrice;
         $this->textAmount = $textAmount;
+
+        $this->textDeleteModal = $textDeleteModal;
     }
 
     protected function getTextRecurringType($type, $textRecurringType)

--- a/resources/views/components/documents/show/top-buttons.blade.php
+++ b/resources/views/components/documents/show/top-buttons.blade.php
@@ -96,10 +96,10 @@
                 @can($permissionDocumentDelete)
                     @if ($checkButtonReconciled)
                         @if (!$document->reconciled)
-                            {!! Form::deleteLink($document, $routeButtonDelete, $textDeleteModal) !!}
+                            {!! Form::deleteLink($document, $routeButtonDelete, $textDeleteModal, 'document_number') !!}
                         @endif
                     @else
-                        {!! Form::deleteLink($document, $routeButtonDelete, $textDeleteModal) !!}
+                        {!! Form::deleteLink($document, $routeButtonDelete, $textDeleteModal, 'document_number') !!}
                     @endif
                 @endcan
             @endif

--- a/resources/views/components/documents/show/top-buttons.blade.php
+++ b/resources/views/components/documents/show/top-buttons.blade.php
@@ -96,10 +96,10 @@
                 @can($permissionDocumentDelete)
                     @if ($checkButtonReconciled)
                         @if (!$document->reconciled)
-                            {!! Form::deleteLink($document, $routeButtonDelete) !!}
+                            {!! Form::deleteLink($document, $routeButtonDelete, $textDeleteModal) !!}
                         @endif
                     @else
-                        {!! Form::deleteLink($document, $routeButtonDelete) !!}
+                        {!! Form::deleteLink($document, $routeButtonDelete, $textDeleteModal) !!}
                     @endif
                 @endcan
             @endif


### PR DESCRIPTION
This PR does the following:
1. allows for modules to provide the correct title and message
2. shows a document number for documents (similar as it generally was showing an object's name, like the name of an item or the name of contact)

Before:

![2021-01-04 05-38-41 Ubuntu Mate 19 10 (Снимок 172)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/103491710-2335a300-4e50-11eb-90f6-46216a6fc9e6.png)

After:

![2021-01-04 05-37-45 Ubuntu Mate 19 10 (Снимок 172)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/103491714-292b8400-4e50-11eb-81a5-12cf4788e08d.png)
