### PR TITLE
Allow to use the script component with modules' custom scripts.

### DIFF
--- a/app/View/Components/Documents/Script.php
+++ b/app/View/Components/Documents/Script.php
@@ -15,6 +15,9 @@ class Script extends Component
     /** @var string */
     public $scriptFile;
 
+    /** @var string */
+    public $version;
+
     public $items;
 
     public $currencies;
@@ -26,10 +29,11 @@ class Script extends Component
      *
      * @return void
      */
-    public function __construct(string $type = '', string $scriptFile = '', $items = [], $currencies = [], $taxes = [])
+    public function __construct(string $type = '', string $scriptFile = '', string $version = '', $items = [], $currencies = [], $taxes = [])
     {
         $this->type = $type;
         $this->scriptFile = ($scriptFile) ? $scriptFile : 'public/js/common/documents.js';
+        $this->version = $this->getVersion($version);
         $this->items = $items;
         $this->currencies = $this->getCurrencies($currencies);
         $this->taxes = $this->getTaxes($taxes);
@@ -43,6 +47,19 @@ class Script extends Component
     public function render()
     {
         return view('components.documents.script');
+    }
+
+    protected function getVersion($version)
+    {
+        if (!empty($version)) {
+            return $version;
+        }
+
+        if ($alias = config('type.' . $this->type . '.alias')) {
+            return module_version($alias);
+        }
+
+        return version('short');
     }
 
     protected function getCurrencies($currencies)

--- a/resources/views/components/documents/script.blade.php
+++ b/resources/views/components/documents/script.blade.php
@@ -15,4 +15,4 @@
     var document_taxes = {!! $taxes !!};
 </script>
 
-<script src="{{ asset( $scriptFile . '?v=' . version('short')) }}"></script>
+<script src="{{ asset( $scriptFile . '?v=' . $version) }}"></script>


### PR DESCRIPTION
It automatically uses the correct version (core's or module's) to bypass a browser's cache.

An example of usage:

    <x-documents.script
        type="debit-note"
        script-file="modules/CreditDebitNotes/Resources/assets/js/debit_notes/documents.min.js"
        :items="$debit_note->items"
    />
