### PR TITLE
Fix getting the document template.

### DIFF
--- a/app/Abstracts/View/Components/DocumentShow.php
+++ b/app/Abstracts/View/Components/DocumentShow.php
@@ -566,7 +566,7 @@ abstract class DocumentShow extends Base
             return $template;
         }
 
-        $documentTemplate = setting($type . '.template') !== null ?: 'default';
+        $documentTemplate = setting($type . '.template') ?: 'default';
 
         return $documentTemplate;
     }


### PR DESCRIPTION
Otherwise, it returns `true` or `default` only.

It could also be `$documentTemplate = setting($type . '.template') !== null ? setting($type . '.template') : 'default';`, but I think that my variant will do.