### PR TITLE
Allow to use custom warning about existing relations in modules.

### DIFF
--- a/app/Traits/Relationships.php
+++ b/app/Traits/Relationships.php
@@ -3,6 +3,7 @@
 namespace App\Traits;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
 
 trait Relationships
 {
@@ -15,7 +16,8 @@ trait Relationships
                 continue;
             }
 
-            $counter[] = $c . ' ' . strtolower(trans_choice('general.' . $text, ($c > 1) ? 2 : 1));
+            $text = Str::contains($text, '::') ? $text : 'general.' . $text;
+            $counter[] = $c . ' ' . strtolower(trans_choice($text, ($c > 1) ? 2 : 1));
         }
 
         return $counter;


### PR DESCRIPTION
With this PR, in a module, we'll be able to provide the text like `employees::general.employees`, and it will be correctly translated. An example: https://github.com/akaunting/module-employees/blob/master/Jobs/Position/DeletePosition.php#L35-L42

Before, it provided something like `general.employees::general.employees` as a translation key, which couldn't be translated, of course.