### PR TITLE
Do not install extra modules when testing.

### DIFF
--- a/app/Listeners/Module/InstallExtraModules.php
+++ b/app/Listeners/Module/InstallExtraModules.php
@@ -6,6 +6,7 @@ use App\Events\Module\Installed as Event;
 use App\Jobs\Install\DownloadModule;
 use App\Jobs\Install\InstallModule;
 use App\Traits\Jobs;
+use Illuminate\Support\Facades\App;
 
 class InstallExtraModules
 {
@@ -19,6 +20,10 @@ class InstallExtraModules
      */
     public function handle(Event $event)
     {
+        if (App::environment('testing')) {
+            return;
+        }
+
         $module = module($event->alias);
 
         $extra_modules = $module->get('extra-modules');


### PR DESCRIPTION
Otherwise, it tries to download and install extra modules. Besides the fact that such a module could be even not published yet, it crashes even before sending an HTTP request. Because of the Eloquent/Builder/SQLIte not being initialized properly at that stage, I think. It doesn't add the table prefix and therefore can't find the table:
```
Working directory: /home/pavel/Code/akaunting-fork

Output:
================
Downloading module...
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'akaunting-fork.companies' doesn't exist (SQL: select count(*) as aggregate from `companies` where `companies`.`deleted_at` is null)
```

But nevermind, it shouldn't install extra modules in a testing environment.

@denisdulici your opinion?