### PR TITLE
onCalculateTotal should be called with timeout

### DIFF
--- a/resources/assets/js/views/common/documents.js
+++ b/resources/assets/js/views/common/documents.js
@@ -309,7 +309,9 @@ const app = new Vue({
                 // invoice_item_checkbox_sample: [],
             });
 
-            this.onCalculateTotal();
+            setTimeout(function() {
+                this.onCalculateTotal();
+            }.bind(this), 800);
         },
 
         onSelectedTax(item_index) {


### PR DESCRIPTION
onCalculateTotal on document.js should be called with timeout because `items` and `form.items` have to be synchronized.