### PR TITLE
Do not include jQuery twice.

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -8,7 +8,9 @@ window._ = require('lodash');
  */
 
 try {
-    window.$ = window.jQuery = require('jquery');
+    if (!window.$) {
+        window.$ = window.jQuery = require('jquery');
+    }
 
     //require('bootstrap-sass');
 } catch (e) {}


### PR DESCRIPTION
This PR prevents including jQuery multiple times. For now, the `bootstrap.js` file, that contains jQuery initialization, is included practically in every JS script, thus initializing jQuery multiple times. Example: https://github.com/akaunting/akaunting/blob/master/resources/assets/js/views/common/search.js#L7

This results in Bootstrap JS plugins not working, cause Bootstrap initializes them only once when its script is loading, and new jQuery instances simply don't have such plugins installed.

Steps to check that for now Bootstrap plugins can't be used through JS:

1. Open a customer details
2. Type in the browser console `$('#invoices-tab').tab('show')`
3. Error will appear, saying `Uncaught TypeError: $(...).tab is not a function`

With working Bootstrap's Tab plugin the "Invoices" tab would be programmatically activated.