### PR TITLE
quarterly based reports

### DIFF
--- a/app/Abstracts/Report.php
+++ b/app/Abstracts/Report.php
@@ -278,27 +278,11 @@ abstract class Report
                 case 'yearly':
                     $start->addYear();
 
-                    $date = $this->getFormattedDate($start);
-
-                    $this->dates[$j] = $date;
-
-                    foreach ($this->tables as $table) {
-                        $this->footer_totals[$table][$date] = 0;
-                    }
-
                     $j += 11;
 
                     break;
                 case 'quarterly':
                     $start->addQuarter();
-
-                    $date = $this->getFormattedDate($start);
-
-                    $this->dates[$j] = $date;
-
-                    foreach ($this->tables as $table) {
-                        $this->footer_totals[$table][$date] = 0;
-                    }
 
                     $j += 2;
 
@@ -306,15 +290,15 @@ abstract class Report
                 default:
                     $start->addMonth();
 
-                    $date = $this->getFormattedDate($start);
-
-                    $this->dates[$j] = $date;
-
-                    foreach ($this->tables as $table) {
-                        $this->footer_totals[$table][$date] = 0;
-                    }
-
                     break;
+            }
+
+            $date = $this->getFormattedDate($start);
+
+            $this->dates[] = $date;
+
+            foreach ($this->tables as $table) {
+                $this->footer_totals[$table][$date] = 0;
             }
         }
     }


### PR DESCRIPTION
Reports that are designed to work quarter based should take financial year start into consideration.
For example, if the financial year start is defined as 1 Feb, the first quarter of the report has to between Feb and Apr. On the contrary, it has been calculated between Jan and Mar before this pull request.