### PR TITLE
Allow modules to provide a translation for a search filter.

### DIFF
--- a/app/View/Components/SearchString.php
+++ b/app/View/Components/SearchString.php
@@ -33,26 +33,26 @@ class SearchString extends Component
     {
         if (empty($this->filters)) {
             $search_string = config('search-string');
-    
+
             $this->filters = [];
-    
+
             if (!empty($search_string[$this->model])) {
                 $columns = $search_string[$this->model]['columns'];
-    
+
                 foreach ($columns as $column => $options) {
                     // This column skip for filter
                     if (!empty($options['searchable'])) {
                         continue;
                     }
-    
+
                     if (!is_array($options)) {
                         $column = $options;
                     }
-    
+
                     if (!$this->isFilter($column, $options)) {
                         continue;
                     }
-    
+
                     $this->filters[] = [
                         'key' => $this->getFilterKey($column, $options),
                         'value' => $this->getFilterName($column, $options),
@@ -101,19 +101,29 @@ class SearchString extends Component
 
         $plural = Str::plural($column, 2);
 
-        if (trans_choice('general.' . $plural, 1) !== 'general.' . $plural) {
-            return trans_choice('general.' . $plural, 1);
-        } elseif (trans_choice('search_string.columns.' . $plural, 1) !== 'search_string.columns.' . $plural) {
-            return trans_choice('search_string.columns.' . $plural, 1);
+        if (strpos($this->model, 'Modules') !== false) {
+            $module_class = explode('\\', $this->model);
+
+            $prefix = Str::slug($module_class[1], '-') . '::';
+
+            $translation_keys[] = $prefix . 'general.';
+            $translation_keys[] = $prefix . 'search_string.columns.';
         }
 
-        $name = trans('general.' . $column);
+        $translation_keys[] = 'general.';
+        $translation_keys[] = 'search_string.columns.';
 
-        if ($name == 'general.' . $column) {
-            $name = trans('search_string.columns.' . $column);
+        foreach ($translation_keys as $translation_key) {
+            if (trans_choice($translation_key . $plural, 1) !== $translation_key . $plural) {
+                return trans_choice($translation_key . $plural, 1);
+            }
+
+            if (trans($translation_key . $column) !== $translation_key . $column) {
+                return trans($translation_key . $column);
+            }
         }
 
-        return $name;
+        return $column;
     }
 
     protected function getFilterType($options)


### PR DESCRIPTION
With this PR the `SearchString` class will check for a module's `search_string.php` "lang" file. Actually, it just adds the `$prefix` for modules.

For now, search filters/parameters look like this: 
![2021-02-08 13-44-11 Ubuntu Mate 19 10 (Снимок 28)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/107192551-f6a91400-6a17-11eb-9da5-00304e3020e4.png)

And using this PR's code it will be: 
![2021-02-08 14-15-04 Ubuntu Mate 19 10 (Снимок 28)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/107192638-104a5b80-6a18-11eb-9962-965da634205b.png)

