### PR TITLE
Show a correct text in a delete modal for modules

### DIFF
--- a/app/Abstracts/View/Components/Document.php
+++ b/app/Abstracts/View/Components/Document.php
@@ -11,7 +11,7 @@ abstract class Document extends Component
     {
         $translation = '';
 
-        // if set config trasnlation config_key
+        // if set config translation config_key
         if ($translation = config('type.' . $type . '.translation.' . $config_key)) {
             return $translation;
         }

--- a/app/Abstracts/View/Components/DocumentIndex.php
+++ b/app/Abstracts/View/Components/DocumentIndex.php
@@ -210,7 +210,7 @@ abstract class DocumentIndex extends Base
         string $textDocumentNumber = '', string $textContactName = '', string $classAmount = '', string $textIssuedAt = '', string $textDueAt = '', string $textDocumentStatus = '',
         bool $checkButtonReconciled = true, bool $checkButtonCancelled = true,
         string $routeButtonShow = '', string $routeButtonEdit = '', string $routeButtonDuplicate = '', string $routeButtonCancelled = '', string $routeButtonDelete = '',
-        string $textModalDelete = '', string $valueModalDelete = 'name',
+        string $textModalDelete = '', string $valueModalDelete = 'document_number',
         bool $hideDocumentNumber = false, bool $hideContactName = false, bool $hideAmount = false, bool $hideIssuedAt = false, bool $hideDueAt = false, bool $hideStatus = false, bool $hideActions = false,
         bool $hideButtonShow = false, bool $hideButtonEdit = false, bool $hideButtonDuplicate = false, bool $hideButtonCancel = false, bool $hideButtonDelete = false,
         string $permissionCreate = '', string $permissionUpdate = '', string $permissionDelete = ''

--- a/app/Abstracts/View/Components/DocumentIndex.php
+++ b/app/Abstracts/View/Components/DocumentIndex.php
@@ -155,6 +155,12 @@ abstract class DocumentIndex extends Base
     /** @var string */
     public $routeButtonDelete;
 
+    /** @var string */
+    public $textModalDelete;
+
+    /** @var string */
+    public $valueModalDelete;
+
     /** @var bool */
     public $hideButtonShow;
 
@@ -194,7 +200,7 @@ abstract class DocumentIndex extends Base
      * @return void
      */
     public function __construct(
-        string $type, $documents = [], $limits = [], 
+        string $type, $documents = [], $limits = [],
         string $imageEmptyPage = '', string $textEmptyPage = '', string $textPage = '', string $urlDocsPath = '', $hideEmptyPage = false,
         bool $checkPermissionCreate = true, string $createRoute = '', string $importRoute = '', array $importRouteParameters = [], string $exportRoute = '',
         bool $hideCreate = false, bool $hideImport = false, bool $hideExport = false, // Advanced
@@ -204,6 +210,7 @@ abstract class DocumentIndex extends Base
         string $textDocumentNumber = '', string $textContactName = '', string $classAmount = '', string $textIssuedAt = '', string $textDueAt = '', string $textDocumentStatus = '',
         bool $checkButtonReconciled = true, bool $checkButtonCancelled = true,
         string $routeButtonShow = '', string $routeButtonEdit = '', string $routeButtonDuplicate = '', string $routeButtonCancelled = '', string $routeButtonDelete = '',
+        string $textModalDelete = '', string $valueModalDelete = 'name',
         bool $hideDocumentNumber = false, bool $hideContactName = false, bool $hideAmount = false, bool $hideIssuedAt = false, bool $hideDueAt = false, bool $hideStatus = false, bool $hideActions = false,
         bool $hideButtonShow = false, bool $hideButtonEdit = false, bool $hideButtonDuplicate = false, bool $hideButtonCancel = false, bool $hideButtonDelete = false,
         string $permissionCreate = '', string $permissionUpdate = '', string $permissionDelete = ''
@@ -259,6 +266,9 @@ abstract class DocumentIndex extends Base
         $this->routeButtonDuplicate = $this->getRouteButtonDuplicate($type, $routeButtonDuplicate);
         $this->routeButtonCancelled = $this->getRouteButtonCancelled($type, $routeButtonCancelled);
         $this->routeButtonDelete = $this->getRouteButtonDelete($type, $routeButtonDelete);
+
+        $this->textModalDelete = $this->getTextModalDelete($type, $textModalDelete);
+        $this->valueModalDelete = $valueModalDelete;
 
         $this->hideBulkAction = $hideBulkAction;
         $this->hideDocumentNumber = $hideDocumentNumber;
@@ -913,6 +923,19 @@ abstract class DocumentIndex extends Base
         }
 
         return 'invoices.destroy';
+    }
+
+    protected function getTextModalDelete($type, $textModalDelete)
+    {
+        if (!empty($textModalDelete)) {
+            return $textModalDelete;
+        }
+
+        if ($alias = config('type.' . $type . '.alias')) {
+            return $alias . '::general.' . Str::plural(str_replace('-', '_', $type));
+        }
+
+        return '';
     }
 
     protected function getPermissionCreate($type, $permissionCreate)

--- a/resources/views/components/documents/index/card-body.blade.php
+++ b/resources/views/components/documents/index/card-body.blade.php
@@ -242,10 +242,10 @@
                                         @can($permissionDelete)
                                             @if ($checkButtonReconciled)
                                                 @if (!$item->reconciled)
-                                                    {!! Form::deleteLink($item, $routeButtonDelete) !!}
+                                                    {!! Form::deleteLink($item, $routeButtonDelete, $textModalDelete, $valueModalDelete) !!}
                                                 @endif
                                             @else
-                                                {!! Form::deleteLink($item, $routeButtonDelete) !!}
+                                                {!! Form::deleteLink($item, $routeButtonDelete, $textModalDelete, $valueModalDelete) !!}
                                             @endif
                                         @endcan
                                     @endif

--- a/resources/views/components/documents/index/content.blade.php
+++ b/resources/views/components/documents/index/content.blade.php
@@ -51,6 +51,8 @@
             hide-button-delete="{{ $hideButtonDelete }}"
             permission-delete="{{ $permissionDelete }}"
             route-button-delete="{{ $routeButtonDelete }}"
+            text-modal-delete="{{ $textModalDelete }}"
+            value-modal-delete="{{ $valueModalDelete }}"
         />
 
         <x-documents.index.card-footer


### PR DESCRIPTION
This PR adds 2 variables in the DocumentIndex blade component that allow a module to provide options for a delete modal. It also assumes that a translation string is "module_alias::general.document_type", so using this convention we don't need to change the existing modules' code.

The core documents will benefit from this change too - in a delete modal dialog a document number will be shown.

Before:

![2021-02-17 09-02-10 Ubuntu Mate 19 10 (Снимок 43)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/108157087-289f3200-710c-11eb-88c1-c33b84743107.png)

After:

![2021-02-17 09-33-48 Ubuntu Mate 19 10 (Снимок 43)  Работает  - Oracle VM VirtualBox   2](https://user-images.githubusercontent.com/7408605/108157101-2dfc7c80-710c-11eb-9c99-f1409d6c37d9.png)
