### PR TITLE
unnecessary code removed

### DIFF
--- a/app/View/Components/SearchString.php
+++ b/app/View/Components/SearchString.php
@@ -15,8 +15,6 @@ class SearchString extends Component
     /** string */
     public $model;
 
-    public $date_format;
-
     /**
      * Create a new component instance.
      *
@@ -26,7 +24,6 @@ class SearchString extends Component
     {
         $this->model = $model;
         $this->filters = $filters;
-        $this->date_format = $this->getCompanyDateFormat();
     }
 
     /**


### PR DESCRIPTION
`$date_format` is removed because `company_date_format` helper will be used in [search-string blade](https://github.com/akaunting/akaunting/blob/7a0fe66cd933cf281997145363777a4790b744d3/resources/views/components/search-string.blade.php#L13) after this [commit](https://github.com/akaunting/akaunting/commit/dc6cba5f5e3dac871c096af665c8d7c12c98f2a2).