### PR TITLE
Fix trying to modify computed value from method

### DIFF
--- a/resources/assets/js/components/AkauntingSelectRemote.vue
+++ b/resources/assets/js/components/AkauntingSelectRemote.vue
@@ -629,12 +629,16 @@ export default {
                 }
 
                 if (path.indexOf('?search') === -1) {
-                    path += '?search="' + query + '"';
+                    path += '?search=' + query;
                 } else {
-                    path += ' "' + query + '"';
+                    path += query;
                 }
 
-                path += ' limit:10';
+                if (path.indexOf('?') + 1) {
+					path += '&limit=10';
+				} else {
+					path += '?limit=10';
+				}
 
                 path += '&currency_code=' + this.currencyCode;
 
@@ -662,7 +666,7 @@ export default {
                             });
                         }, this);
                     } else {
-                        this.sortOptions = [];
+                        this.sort_options = [];
                     }
                 })
                 .catch(e => {


### PR DESCRIPTION
In the remoteMethod, when the response does not have data, it tries to modify the compute value "sortOption". this I noticed when I removed the response when testing features on my pc.

also in the remoteMethod, the limit is joined as a search keyword when searching