### PR TITLE
Lock the phpspreadsheet version to 1.16.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "maatwebsite/excel": "3.1.*",
         "mnsami/composer-custom-directory-installer": "2.0.*",
         "monooso/unobserve": "^3.0",
+        "phpoffice/phpspreadsheet": "1.16",
         "plank/laravel-mediable": "4.4.*",
         "riverskies/laravel-mobile-detect": "^1.3",
         "santigarcor/laratrust": "6.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea0246832221b1db0a2c2a2af2280c6b",
+    "content-hash": "ed7f9185c4b320bd65bb1b8e281eeecf",
     "packages": [
         {
             "name": "akaunting/laravel-firewall",
@@ -7711,16 +7711,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.17.1",
+            "version": "1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "c55269cb06911575a126dc225a05c0e4626e5fb4"
+                "reference": "76d4323b85129d0c368149c831a07a3e258b2b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/c55269cb06911575a126dc225a05c0e4626e5fb4",
-                "reference": "c55269cb06911575a126dc225a05c0e4626e5fb4",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/76d4323b85129d0c368149c831a07a3e258b2b50",
+                "reference": "76d4323b85129d0c368149c831a07a3e258b2b50",
                 "shasum": ""
             },
             "require": {
@@ -7748,7 +7748,7 @@
             },
             "require-dev": {
                 "dompdf/dompdf": "^0.8.5",
-                "friendsofphp/php-cs-fixer": "^2.18",
+                "friendsofphp/php-cs-fixer": "^2.16",
                 "jpgraph/jpgraph": "^4.0",
                 "mpdf/mpdf": "^8.0",
                 "phpcompatibility/php-compatibility": "^9.3",
@@ -7806,9 +7806,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.17.1"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.16.0"
             },
-            "time": "2021-03-02T17:54:11+00:00"
+            "time": "2020-12-31T18:03:49+00:00"
         },
         {
             "name": "phpoption/phpoption",


### PR DESCRIPTION
Fixes #1918.

This is a temporary workaround for imports to work.
Additional info: https://github.com/Maatwebsite/Laravel-Excel/issues/3057#issuecomment-790726533