### PR TITLE
Remove a redundant dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "maatwebsite/excel": "3.1.*",
         "mnsami/composer-custom-directory-installer": "2.0.*",
         "monooso/unobserve": "^3.0",
-        "phpoffice/phpspreadsheet": "1.16",
         "plank/laravel-mediable": "4.4.*",
         "riverskies/laravel-mobile-detect": "^1.3",
         "santigarcor/laratrust": "6.3.*",


### PR DESCRIPTION
We don't need to freeze the `phpoffice/phpspreadsheet` version anymore because the `maatwebsite/excel` version [3.1.28](https://github.com/Maatwebsite/Laravel-Excel/blob/3.1/CHANGELOG.md#3128---2021-03-10) does this.