### PR TITLE
Fix landing page issue

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,8 +5,8 @@ namespace App\Exceptions;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -71,11 +71,13 @@ class Handler extends ExceptionHandler
     protected function unauthenticated($request, AuthenticationException $exception)
     {
         // Store the current url in the session
-        session(['url.intended' => $request->url()]);
+        if ($request->url() !== config('app.url')) {
+            session(['url.intended' => $request->url()]);
+        }
 
         return $request->expectsJson()
-                    ? response()->json(['message' => $exception->getMessage()], 401)
-                    : redirect()->guest($exception->redirectTo() ?? route('login'));
+            ? response()->json(['message' => $exception->getMessage()], 401)
+            : redirect()->to($exception->redirectTo() ?? route('login'));
     }
 
     private function handleExceptions($request, $exception)


### PR DESCRIPTION
If the unauthenticated user goes to the base URL, Akaunting redirects the user to the login page but with the previous URL. When it does, the user is never redirected to the landing page.
