### PR TITLE
Move document footer to the end of the document

### DIFF
--- a/public/css/print.css
+++ b/public/css/print.css
@@ -488,3 +488,9 @@ th, td
     background-color: #f6f9fc;
     text-decoration: none;
 }
+
+.clearfix:after {
+	display: block;
+	clear: both;
+	content: ""
+}

--- a/resources/views/components/documents/template/classic.blade.php
+++ b/resources/views/components/documents/template/classic.blade.php
@@ -228,7 +228,7 @@
     </div>
 </div>
 
-<div class="row mt-4">
+<div class="row mt-4 clearfix">
     <div class="col-58">
         <div class="text company">
             @stack('notes_input_start')

--- a/resources/views/components/documents/template/default.blade.php
+++ b/resources/views/components/documents/template/default.blade.php
@@ -212,7 +212,7 @@
     </div>
 </div>
 
-<div class="row mt-9">
+<div class="row mt-9 clearfix">
     <div class="col-58">
         <div class="text company">
             @stack('notes_input_start')


### PR DESCRIPTION
When creating PDF files of bills the footer section is moved to the left besides the invoice summary. This would ensure to keep the footer below the summary