### PR TITLE
Fix the import page title for modules.

### DIFF
--- a/app/Http/Controllers/Common/Import.php
+++ b/app/Http/Controllers/Common/Import.php
@@ -20,6 +20,7 @@ class Import extends Controller
 
         if (module($group) instanceof \Akaunting\Module\Module) {
             $namespace = $group . '::';
+            $type = str_replace('-', '_', $type);
         } else {
             $namespace = '';
         }


### PR DESCRIPTION
In multi-word routes, we use the `-` as a delimiter, but we use the `_` instead of in the translation keys. So at least for modules, it needs a basic character replacement, which this PR proposes.

Though I see that in the import "xlsx" templates' names the underscore is used, it could be not true for all modules, so this part needs checking before approving this PR, cause the back-compatibility break can happen.