### PR TITLE
'Element-ui popper position bugfix solved'

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -9,6 +9,10 @@
     font-style: normal;
 }
 
+body {
+    height: 100%;
+}
+
 /*--Layout Content--*/
 .content-layout {
     max-width: 1300px !important;


### PR DESCRIPTION
While using popper.js with element-ui select component, problem occured. 'Placement' attributed not change by the window size. Because there are many 'position:relative' elements in the page, it is not work. I referenced body tag and problem solved. 
My source: https://stackoverflow.com/questions/49846841/vuejs-element-ui-absolute-positioned-div-in-relative-div-on-v-for  