### PR TITLE
Allow modules to provide a custom title for the "advanced" section in a document

### DIFF
--- a/app/Abstracts/View/Components/DocumentForm.php
+++ b/app/Abstracts/View/Components/DocumentForm.php
@@ -28,6 +28,9 @@ abstract class DocumentForm extends Base
     /** @var string */
     public $categoryType;
 
+    /** @var string */
+    public $textAdvancedAccordion;
+
     /** @var bool */
     public $hideRecurring;
 
@@ -214,7 +217,7 @@ abstract class DocumentForm extends Base
     public function __construct(
         $type, $document = false, $currencies = false, $currency = false, $currency_code = false,
         /** Advanced Component Start */
-        string $categoryType = '', bool $hideRecurring = false, bool $hideCategory = false, bool $hideAttachment = false,
+        string $categoryType = '', string $textAdvancedAccordion = '', bool $hideRecurring = false, bool $hideCategory = false, bool $hideAttachment = false,
         /** Advanced Component End */
         /** Company Component Start */
         bool $hideLogo = false, bool $hideDocumentTitle = false, bool $hideDocumentSubheading = false, bool $hideCompanyEdit = false,
@@ -248,6 +251,7 @@ abstract class DocumentForm extends Base
 
         /** Advanced Component Start */
         $this->categoryType = $this->getCategoryType($type, $categoryType);
+        $this->textAdvancedAccordion = $this->getTextAdvancedAccordion($type, $textAdvancedAccordion);
         $this->hideRecurring = $hideRecurring;
         $this->hideCategory = $hideCategory;
         $this->hideAttachment = $hideAttachment;
@@ -413,6 +417,21 @@ abstract class DocumentForm extends Base
         $type = Document::INVOICE_TYPE;
 
         return config('type.' . $type . '.category_type');
+    }
+
+    protected function getTextAdvancedAccordion($type, $textAdvancedAccordion)
+    {
+        if (!empty($textAdvancedAccordion)) {
+            return $textAdvancedAccordion;
+        }
+
+        $translation = $this->getTextFromConfig($type, 'advanced_accordion');
+
+        if (!empty($translation)) {
+            return $translation;
+        }
+
+        return 'general.recurring_and_more';
     }
 
     protected function getContacts($type, $contacts)

--- a/resources/views/components/documents/form/advanced.blade.php
+++ b/resources/views/components/documents/form/advanced.blade.php
@@ -1,7 +1,7 @@
 <div class="accordion">
     <div class="card border-1 box-shadow-none">
         <div class="card-header background-none collapsed" id="accordion-recurring-and-more-header" data-toggle="collapse" data-target="#accordion-recurring-and-more-body" aria-expanded="false" aria-controls="accordion-recurring-and-more-body">
-            <h4 class="mb-0">{{ trans('general.recurring_and_more') }}</h4>
+            <h4 class="mb-0">{{ trans($textAdvancedAccordion) }}</h4>
         </div>
 
         <div id="accordion-recurring-and-more-body" class="collapse hide" aria-labelledby="accordion-recurring-and-more-header">


### PR DESCRIPTION
This PR allows modules to change the standard `Recurring and more...` title to a custom text. Useful for documents that don't use recurring, such as expense claims: https://github.com/akaunting/module-expenses/issues/22.

An example of using this feature in a module: https://github.com/akaunting/module-expenses/commit/783d635d664b3f49a74ca98d94af2913bc2068f2

![2021-05-26 12-24-06 Рабочий стол](https://user-images.githubusercontent.com/7408605/119612215-715a3b80-be1d-11eb-91e9-0a88966a47b8.png)
