### PR TITLE
Date time picker can't correct work when I change default language.

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -13,6 +13,10 @@ body {
     height: 100%;
 }
 
+.datepicker[readonly] {
+    background-color: transparent !important;
+}
+
 /*--Layout Content--*/
 .content-layout {
     max-width: 1300px !important;

--- a/resources/assets/js/views/wizard/Company.vue
+++ b/resources/assets/js/views/wizard/Company.vue
@@ -62,9 +62,10 @@
                                 icon="fas fa-calendar"
                                 :date-config="{
                                   dateFormat: 'd-m',
-                                  allowInput: true,
+                                  allowInput: false,
                                   altInput: true,
                                   altFormat: 'j F',
+                                  locale:require(`flatpickr/dist/l10n/${lang_data}.js`).default[lang_data]
                                 }"
                                 v-model="real_date"
                             ></akaunting-date>
@@ -149,6 +150,11 @@ export default {
 
         pageLoad: {
           type: [Boolean, String]
+        },
+
+        locale: {
+            type: String,
+            default: 'en',
         }
     },
 
@@ -157,7 +163,15 @@ export default {
             active: 0,
             logo: [],
             real_date: "",
+            lang_data: ''
         };
+    },
+
+    created() {
+        if(document.documentElement.lang) {
+            let lang_split = document.documentElement.lang.split("-");
+            this.lang_data = lang_split[0];
+        }
     },
 
     mounted() {

--- a/resources/views/layouts/wizard.blade.php
+++ b/resources/views/layouts/wizard.blade.php
@@ -1,4 +1,4 @@
-<html>
+<html lang="{{ app()->getLocale() }}">
     @include('partials.wizard.head')
 
     <body class="wizard-page">

--- a/resources/views/partials/form/date_group.blade.php
+++ b/resources/views/partials/form/date_group.blade.php
@@ -26,7 +26,7 @@
 
         :date-config="{
             wrap: true, // set wrap to true only when using 'input-group'
-            allowInput: true,
+            allowInput: false,
             @if (!empty($attributes['show-date-format']))
             altInput: true,
             altFormat: '{{ $attributes['show-date-format'] }}',


### PR DESCRIPTION
When I select February (Şubat Turkish month), it throws it to January (Ocak Turkish month).

**-I selected this month**
<img width="509" alt="Screen Shot 2021-06-01 at 17 23 14" src="https://user-images.githubusercontent.com/22003497/120350013-441ef900-c307-11eb-8780-77deee7fe604.png">


**when i click on an empty space** This status cause by It is welded in the letter "Ş"**
<img width="513" alt="Screen Shot 2021-06-01 at 18 32 33" src="https://user-images.githubusercontent.com/22003497/120350580-cad3d600-c307-11eb-828c-b021e858a0c6.png">

**Result:** When I selected _allowInput_ attribute _false_, flatpicker module can correct work.
