### PR TITLE
Named parameter in PHP 8

### DIFF
--- a/app/Abstracts/View/Components/DocumentTemplate.php
+++ b/app/Abstracts/View/Components/DocumentTemplate.php
@@ -116,7 +116,7 @@ abstract class DocumentTemplate extends Base
      * @return void
      */
     public function __construct(
-        $type, $item = false, $document, $documentTemplate = '', $logo = '', $backgroundColor = '',
+        $type, $document, $item = false,  $documentTemplate = '', $logo = '', $backgroundColor = '',
         bool $hideFooter = false, bool $hideCompanyLogo = false, bool $hideCompanyDetails = false,
         bool $hideCompanyName = false, bool $hideCompanyAddress = false, bool $hideCompanyTaxNumber = false, bool $hideCompanyPhone = false, bool $hideCompanyEmail = false, bool $hideContactInfo = false,
         bool $hideContactName = false, bool $hideContactAddress = false, bool $hideContactTaxNumber = false, bool $hideContactPhone = false, bool $hideContactEmail = false,


### PR DESCRIPTION
Named parameters were introduced in PHP 8. Parameters without default values must now appear PRIOR to optional parameters. When you use akaunting in PHP 8, it throws an error when you need to view invoices. 