### PR TITLE
Left menu active item color fix

### DIFF
--- a/public/css/akaunting-color.css
+++ b/public/css/akaunting-color.css
@@ -2294,6 +2294,10 @@ div.required > .form-control-label:not(span):after, td.required:after
 
 
 /*--------Nav Pills Color--------*/
+.navbar-light .navbar-nav .nav-link {
+    color: #ffffff !important;
+}
+
 .nav-link
 {
     color: #3c3f72;


### PR DESCRIPTION
When item active on the left menu, active item color not show at first glance. I fixed this problem.
<img width="208" alt="Screen Shot 2021-06-11 at 14 01 50" src="https://user-images.githubusercontent.com/22003497/121676686-97d6d280-cabd-11eb-9840-b85678ce8207.png">
