### PR TITLE
Long text problem at the Invoice and Bills page.

### DIFF
--- a/resources/assets/js/components/AkauntingContactCard.vue
+++ b/resources/assets/js/components/AkauntingContactCard.vue
@@ -79,27 +79,27 @@
                         <table class="table table-borderless p-0">
                             <tbody>
                                 <tr>
-                                    <th class="p-0">
+                                    <th class="p-0" style="text-align:left;">
                                         <strong class="d-block">{{ contact.name }}</strong>
                                     </th>
                                 </tr>
                                 <tr>
-                                    <th class="p-0">
+                                    <th class="p-0" style="text-align:left; white-space: normal;">
                                         {{ contact.address }}
                                     </th>
                                 </tr>
                                 <tr v-if="contact.tax_number">
-                                    <th class="p-0">
+                                    <th class="p-0" style="text-align:left;">
                                         {{ taxNumberText }}: {{ contact.tax_number }}
                                     </th>
                                 </tr>
                                 <tr v-if="contact.phone">
-                                    <th class="p-0">
+                                    <th class="p-0" style="text-align:left;">
                                         {{ contact.phone }}
                                     </th>
                                 </tr>
                                 <tr v-if="contact.email">
-                                    <th class="p-0">
+                                    <th class="p-0" style="text-align:left;">
                                         {{ contact.email }}
                                     </th>
                                 </tr>


### PR DESCRIPTION
I fixed styling control to cover this pages and cross browser controlled.

Before development
![121820531-33696e00-cc8b-11eb-8ef2-f7292184322c](https://user-images.githubusercontent.com/22003497/122025528-14c1bf00-cdd2-11eb-9f53-730ede72d592.png)

After development
<img width="1029" alt="Screen Shot 2021-06-15 at 12 06 29" src="https://user-images.githubusercontent.com/22003497/122025586-23a87180-cdd2-11eb-87c2-2095ca0bae05.png">
