### PR TITLE
Allow to use the AkauntingSelectRemote component in a modal dialog.

### DIFF
--- a/resources/assets/js/components/AkauntingModalAddNew.vue
+++ b/resources/assets/js/components/AkauntingModalAddNew.vue
@@ -59,6 +59,7 @@ import AkauntingModal from './AkauntingModal';
 import AkauntingMoney from './AkauntingMoney';
 import AkauntingRadioGroup from './forms/AkauntingRadioGroup';
 import AkauntingSelect from './AkauntingSelect';
+import AkauntingSelectRemote from './AkauntingSelectRemote';
 import AkauntingDate from './AkauntingDate';
 import AkauntingRecurring from './AkauntingRecurring';
 
@@ -138,9 +139,9 @@ export default {
     },
 
     created: function () {
-        let documentClasses = document.body.classList;	
+        let documentClasses = document.body.classList;
 
-        documentClasses.add("modal-open");	
+        documentClasses.add("modal-open");
     },
 
     mounted() {
@@ -154,6 +155,7 @@ export default {
                     components: {
                         AkauntingRadioGroup,
                         AkauntingSelect,
+                        AkauntingSelectRemote,
                         AkauntingModal,
                         AkauntingMoney,
                         AkauntingDate,


### PR DESCRIPTION
This PR allows using of a dropdown with the server-side searching (`AkauntingSelectRemote` component) in a modal dialog. Such an input field is needed in the `Assets` module for [searching/selecting an employee](https://github.com/akaunting/module-assets/blob/master/Resources/views/modals/allotments/create.blade.php#L11). The usual `AkauntingSelect` component is not suitable in this case, as I suppose it's not wise to load all employees into it.