### PR TITLE
Name not show where it is used "col-aka" classname

### DIFF
--- a/app/Abstracts/View/Components/DocumentIndex.php
+++ b/app/Abstracts/View/Components/DocumentIndex.php
@@ -671,7 +671,7 @@ abstract class DocumentIndex extends Base
             return $class;
         }
 
-        return 'col-xs-4 col-sm-4 col-md-4 col-lg-2 col-xl-2 text-left';
+        return 'col-xs-4 col-sm-4 col-md-4 col-lg-2 col-xl-2 text-left long-texts';
     }
 
     protected function getClassAmount($type, $classAmount)

--- a/resources/views/purchases/vendors/index.blade.php
+++ b/resources/views/purchases/vendors/index.blade.php
@@ -47,8 +47,8 @@
                                 <td class="col-sm-2 col-md-1 col-lg-1 col-xl-1 d-none d-sm-block">
                                     {{ Form::bulkActionGroup($item->id, $item->name) }}
                                 </td>
-                                <td class="col-xs-4 col-sm-3 col-md-4 col-lg-3 col-xl-3 long-texts">
-                                    <a class="col-aka" href="{{ route('vendors.show', $item->id) }}">{{ $item->name }}</a>
+                                <td class="col-xs-4 col-sm-3 col-md-4 col-lg-3 col-xl-3">
+                                    <a class="col-aka long-texts d-block" href="{{ route('vendors.show', $item->id) }}">{{ $item->name }}</a>
                                 </td>
                                 <td class="col-md-3 col-lg-3 col-xl-3 d-none d-md-block long-texts">
                                     <el-tooltip content="{{ !empty($item->phone) ? $item->phone : trans('general.na') }}"

--- a/resources/views/sales/customers/index.blade.php
+++ b/resources/views/sales/customers/index.blade.php
@@ -47,8 +47,8 @@
                                 <td class="col-sm-2 col-md-1 col-lg-1 col-xl-1 d-none d-sm-block">
                                     {{ Form::bulkActionGroup($item->id, $item->name) }}
                                 </td>
-                                <td class="col-xs-4 col-sm-3 col-md-4 col-lg-3 col-xl-3 long-texts">
-                                    <a class="col-aka" href="{{ route('customers.show', $item->id) }}">{{ $item->name }}</a>
+                                <td class="col-xs-4 col-sm-3 col-md-4 col-lg-3 col-xl-3">
+                                    <a class="col-aka long-texts d-block" href="{{ route('customers.show', $item->id) }}">{{ $item->name }}</a>
                                 </td>
                                 <td class="col-md-3 col-lg-3 col-xl-3 d-none d-md-block long-texts">
                                     <el-tooltip content="{{ !empty($item->phone) ? $item->phone : trans('general.na') }}"


### PR DESCRIPTION
When I use "col-aka" classname with long text control, name not show. I fixed this problem.