### PR TITLE
Add an ability to the AkauntingSelect component to show options as is…

### DIFF
--- a/resources/views/partials/form/select_group.blade.php
+++ b/resources/views/partials/form/select_group.blade.php
@@ -46,7 +46,7 @@
         @if (!empty($attributes['visible-change']))
         @visible-change="{{ $attributes['visible-change'] }}"
         @endif
-        
+
         @if (isset($attributes['readonly']))
         :readonly="{{ $attributes['readonly'] }}"
         @endif
@@ -67,6 +67,10 @@
 
         no-data-text="{{ trans('general.no_data') }}"
         no-matching-data-text="{{ trans('general.no_matching_data') }}"
+
+        @if (isset($attributes['sort-options']))
+        :sort-options="{{ $attributes['sort-options'] }}"
+        @endif
     ></akaunting-select>
 
 @stack($name . '_input_end')


### PR DESCRIPTION
…, without sorting them.

1. New prop `sortOptions` was added.
2. Existing computed property was renamed to better reflect its content and purpose: `sortOptions` -> `sortedOptions`.
3. Existing data option was renamed to better reflect its content and purpose: `sort_options` -> `sorted_options`.

Examples of using this feature: 
https://github.com/akaunting/module-payroll/blob/3e7946fd64bb8d71dccf24918af6cc83b9f13705/Resources/views/pay-calendars/create.blade.php#L21
https://github.com/akaunting/module-payroll/blob/3e7946fd64bb8d71dccf24918af6cc83b9f13705/Resources/views/pay-calendars/create.blade.php#L40
