### PR TITLE
Allow using the dependent validation rules in import.

### DIFF
--- a/app/Abstracts/Import.php
+++ b/app/Abstracts/Import.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToModel;
@@ -101,5 +102,40 @@ abstract class Import implements HasLocalePreference, ShouldQueue, SkipsEmptyRow
     public function preferredLocale()
     {
         return $this->user->locale;
+    }
+
+    protected function replaceForBatchRules(array $rules): array
+    {
+        $dependent_rules = [
+            'after',
+            'after_or_equal',
+            'before',
+            'before_or_equal',
+            'different',
+            'exclude_if',
+            'exclude_unless',
+            'gt',
+            'gte',
+            'in_array',
+            'lt',
+            'lte',
+            'prohibited_if',
+            'prohibited_unless',
+            'required_if',
+            'required_unless',
+            'required_with',
+            'required_with_all',
+            'required_without',
+            'required_without_all',
+            'same',
+        ];
+
+        foreach ($rules as $field => $rule) {
+            foreach ($dependent_rules as $dependent_rule) {
+                $rules[$field] = Str::replaceFirst($dependent_rule . ':', $dependent_rule . ':*.', $rules[$field]);
+            }
+        }
+
+        return $rules;
     }
 }

--- a/app/Imports/Purchases/Sheets/Bills.php
+++ b/app/Imports/Purchases/Sheets/Bills.php
@@ -36,12 +36,10 @@ class Bills extends Import
         $rules = (new Request())->rules();
 
         $rules['bill_number'] = Str::replaceFirst('unique:documents,NULL', 'unique:documents,document_number', $rules['document_number']);
-        $rules['issued_at'] = Str::replaceFirst('|before_or_equal:due_at', '', $rules['issued_at']);
-        $rules['due_at'] = Str::replaceFirst('|after_or_equal:issued_at', '', $rules['due_at']);
         $rules['billed_at'] = $rules['issued_at'];
 
         unset($rules['document_number'], $rules['issued_at'], $rules['type']);
 
-        return $rules;
+        return $this->replaceForBatchRules($rules);
     }
 }

--- a/app/Imports/Sales/Sheets/Invoices.php
+++ b/app/Imports/Sales/Sheets/Invoices.php
@@ -36,12 +36,10 @@ class Invoices extends Import
         $rules = (new Request())->rules();
 
         $rules['invoice_number'] = Str::replaceFirst('unique:documents,NULL', 'unique:documents,document_number', $rules['document_number']);
-        $rules['issued_at'] = Str::replaceFirst('|before_or_equal:due_at', '', $rules['issued_at']);
-        $rules['due_at'] = Str::replaceFirst('|after_or_equal:issued_at', '', $rules['due_at']);
         $rules['invoiced_at'] = $rules['issued_at'];
 
         unset($rules['document_number'], $rules['issued_at'], $rules['type']);
 
-        return $rules;
+        return $this->replaceForBatchRules($rules);
     }
 }


### PR DESCRIPTION
This PR provides the ability to use dependent validation rules such as: `after`, `after_or_equal`, `before`, `before_or_equal`, `different`, `exclude_if`, `exclude_unless`, `gt`, `gte`, `in_array`, `lt`, `lte`, `prohibited_if`, `prohibited_unless`, `required_if`, `required_unless`, `required_with`, `required_with_all`, `required_without`, `required_without_all`, `same`.

You just return the import rules like this: `return $this->replaceForBatchRules($rules);`

@cuneytsenturk I've manually checked importing of the sample invoices file and have run a PHPUnit test - both passed fine.

@denisdulici would you please test this too?