### PR TITLE
Allow modules to prevent contacts deleting #nka5y8

### DIFF
--- a/app/Events/Common/ContactGettingRelationships.php
+++ b/app/Events/Common/ContactGettingRelationships.php
@@ -6,10 +6,10 @@ use App\Abstracts\Event;
 
 class ContactGettingRelationships extends Event
 {
-    public $rel;
+    public $contact;
 
-    public function __construct($rel)
+    public function __construct($contact)
     {
-        $this->rel = $rel;
+        $this->contact = $contact;
     }
 }

--- a/app/Events/Common/ContactGettingRelationships.php
+++ b/app/Events/Common/ContactGettingRelationships.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events\Common;
+
+use App\Abstracts\Event;
+
+class ContactGettingRelationships extends Event
+{
+    public $rel;
+
+    public function __construct($rel)
+    {
+        $this->rel = $rel;
+    }
+}

--- a/app/Jobs/Common/DeleteContact.php
+++ b/app/Jobs/Common/DeleteContact.php
@@ -3,6 +3,7 @@
 namespace App\Jobs\Common;
 
 use App\Abstracts\Job;
+use App\Events\Common\ContactGettingRelationships;
 use App\Jobs\Auth\DeleteUser;
 use App\Traits\Contacts;
 
@@ -68,6 +69,11 @@ class DeleteContact extends Job
             $rels['bills'] = 'bills';
         }
 
-        return $this->countRelationships($this->contact, $rels);
+        $rel = new \stdClass();
+        $rel->relationships = $rels;
+
+        event(new ContactGettingRelationships($rel));
+
+        return $this->countRelationships($this->contact, $rel->relationships);
     }
 }


### PR DESCRIPTION
This PR allows modules to provide their custom relationships to the `Contact`, thus preventing deleting a contact if there are relationships. Without this, the Core only checks for embedded relationships.

An example from the `Employee` module: https://github.com/akaunting/module-employees/blob/wip/Listeners/PreventContactDeleting.php