### PR TITLE
Date inputs update in relation to admin payment term settings

### DIFF
--- a/resources/assets/js/components/AkauntingDate.vue
+++ b/resources/assets/js/components/AkauntingDate.vue
@@ -150,13 +150,15 @@ export default {
         addDays(dateInput) {
             if(!default_payment_terms) return;
 
+            console.log(dateInput)
             const dateString = new Date(dateInput);
             const aMillisec = 86400000;
             const dateInMillisecs = dateString.getTime();
-            const settingPaymentTermInMs = default_payment_terms * aMillisec;
+            const settingPaymentTermInMs = parseInt(default_payment_terms) * aMillisec;
             const prospectedDueDate = new Date(dateInMillisecs + settingPaymentTermInMs);
 
             return prospectedDueDate;
+            debugger;
         },
     },
 
@@ -167,7 +169,7 @@ export default {
             }
 
             if(this.dateConfig.minDate && this.real_model > this.dateConfig.minDate ){
-                this.real_model = this.addDays(this.real_model);
+                this.real_model = this.addDays(this.dateConfig.minDate);
             }
         },
     }

--- a/resources/assets/js/components/AkauntingDate.vue
+++ b/resources/assets/js/components/AkauntingDate.vue
@@ -110,7 +110,7 @@ export default {
             real_model: '',
         }
     },
-    
+
     created() {
         if (this.locale !== 'en') {
             const lang = require(`flatpickr/dist/l10n/${this.locale}.js`).default[this.locale];
@@ -125,6 +125,8 @@ export default {
         if (this.model) {
             this.real_model = this.model;
         }
+
+        this.$emit('interface', this.real_model);
     },
 
     methods: {
@@ -150,7 +152,6 @@ export default {
         addDays(dateInput) {
             if(!default_payment_terms) return;
 
-            console.log(dateInput)
             const dateString = new Date(dateInput);
             const aMillisec = 86400000;
             const dateInMillisecs = dateString.getTime();
@@ -158,17 +159,20 @@ export default {
             const prospectedDueDate = new Date(dateInMillisecs + settingPaymentTermInMs);
 
             return prospectedDueDate;
-            debugger;
         },
     },
 
     watch: {
+        value: function(val) {
+            this.real_model = val;
+        },
+
         dateConfig: function() {
-            if(!default_payment_terms || this.real_model < this.dateConfig.minDate){
+            if(!default_payment_terms || this.real_model < this.dateConfig.minDate) {
                  this.real_model = this.dateConfig.minDate;
             }
 
-            if(this.dateConfig.minDate && this.real_model > this.dateConfig.minDate ){
+            if(this.dateConfig.minDate && this.real_model > this.dateConfig.minDate ) {
                 this.real_model = this.addDays(this.dateConfig.minDate);
             }
         },

--- a/resources/assets/js/components/AkauntingDate.vue
+++ b/resources/assets/js/components/AkauntingDate.vue
@@ -117,16 +117,14 @@ export default {
 
             this.dateConfig.locale = lang;
         }
+
+        this.real_model = this.value;
     },
 
     mounted() {
-        this.real_model = this.value;
-
         if (this.model) {
             this.real_model = this.model;
         }
-
-        this.$emit('interface', this.real_model);
     },
 
     methods: {
@@ -147,16 +145,30 @@ export default {
                     wrapper.classList.remove('hidden-year-flatpickr');
                 });
             }
-        }
+        },
+
+        addDays(dateInput) {
+            if(!default_payment_terms) return;
+
+            const dateString = new Date(dateInput);
+            const aMillisec = 86400000;
+            const dateInMillisecs = dateString.getTime();
+            const settingPaymentTermInMs = default_payment_terms * aMillisec;
+            const prospectedDueDate = new Date(dateInMillisecs + settingPaymentTermInMs);
+
+            return prospectedDueDate;
+        },
     },
 
     watch: {
-        value: function(val) {
-            this.real_model = val;
-        },
+        dateConfig: function() {
+            if(!default_payment_terms || this.real_model < this.dateConfig.minDate){
+                 this.real_model = this.dateConfig.minDate;
+            }
 
-        dataValueMin: function(val) {
-            this.dateConfig.minDate = val;
+            if(this.dateConfig.minDate && this.real_model > this.dateConfig.minDate ){
+                this.real_model = this.addDays(this.real_model);
+            }
         },
     }
 }

--- a/resources/assets/js/components/AkauntingDate.vue
+++ b/resources/assets/js/components/AkauntingDate.vue
@@ -60,7 +60,7 @@ export default {
             default: false,
             description: "Input readonly status"
         },
-        props: {
+        period: {
             type: Number,
             description: "Payment period"
         },

--- a/resources/assets/js/components/AkauntingDate.vue
+++ b/resources/assets/js/components/AkauntingDate.vue
@@ -60,6 +60,10 @@ export default {
             default: false,
             description: "Input readonly status"
         },
+        props: {
+            type: Number,
+            description: "Payment period"
+        },
         disabled: {
             type: Boolean,
             default: false,
@@ -150,12 +154,12 @@ export default {
         },
 
         addDays(dateInput) {
-            if(!default_payment_terms) return;
+            if(!this.period) return;
 
             const dateString = new Date(dateInput);
             const aMillisec = 86400000;
             const dateInMillisecs = dateString.getTime();
-            const settingPaymentTermInMs = parseInt(default_payment_terms) * aMillisec;
+            const settingPaymentTermInMs = parseInt(this.period) * aMillisec;
             const prospectedDueDate = new Date(dateInMillisecs + settingPaymentTermInMs);
 
             return prospectedDueDate;
@@ -168,12 +172,10 @@ export default {
         },
 
         dateConfig: function() {
-            if(!default_payment_terms || this.real_model < this.dateConfig.minDate) {
-                 this.real_model = this.dateConfig.minDate;
-            }
-
-            if(this.dateConfig.minDate && this.real_model > this.dateConfig.minDate ) {
-                this.real_model = this.addDays(this.dateConfig.minDate);
+           if(this.dateConfig.minDate) { 
+                if(this.real_model < this.dateConfig.minDate){
+                    this.real_model = this.addDays(this.dateConfig.minDate);
+                }
             }
         },
     }

--- a/resources/views/banking/reconciliations/create.blade.php
+++ b/resources/views/banking/reconciliations/create.blade.php
@@ -18,7 +18,7 @@
                 <div class="row align-items-center">
                     {{ Form::dateGroup('started_at', trans('reconciliations.start_date'), 'calendar', ['id' => 'started_at', 'class' => 'form-control datepicker', 'required' => 'required', 'show-date-format' => company_date_format(), 'date-format' => 'Y-m-d', 'autocomplete' => 'off', 'change' => 'setDueMinDate'], request('started_at', Date::now()->firstOfMonth()->toDateString()), 'col-xl-3') }}
 
-                    {{ Form::dateGroup('ended_at', trans('reconciliations.end_date'), 'calendar', ['id' => 'ended_at', 'class' => 'form-control datepicker', 'required' => 'required', 'show-date-format' => company_date_format(), 'date-format' => 'Y-m-d', 'autocomplete' => 'off', 'min-date' => 'form.started_at', 'min-date-dynamic' => 'min_due_date', 'data-value-min' => true], request('ended_at', Date::now()->endOfMonth()->toDateString()), 'col-xl-3') }}
+                    {{ Form::dateGroup('ended_at', trans('reconciliations.end_date'), 'calendar', ['id' => 'ended_at', 'class' => 'form-control datepicker', 'required' => 'required', 'show-date-format' => company_date_format(), 'date-format' => 'Y-m-d', 'autocomplete' => 'off', 'min-date' => 'form.started_at', 'min-date-dynamic' => 'min_due_date', 'data-value-min' => true, 'period' => 30], request('ended_at', Date::now()->endOfMonth()->toDateString()), 'col-xl-3') }}
 
                     {{ Form::moneyGroup('closing_balance', trans('reconciliations.closing_balance'), 'balance-scale', ['required' => 'required', 'autofocus' => 'autofocus', 'currency' => $currency, 'dynamic-currency' => 'currency', 'input' => 'onCalculate'], request('closing_balance', 0.00), 'col-xl-2') }}
 

--- a/resources/views/components/documents/form/metadata.blade.php
+++ b/resources/views/components/documents/form/metadata.blade.php
@@ -30,7 +30,7 @@
             @endif
 
             @if (!$hideDueAt)
-            {{ Form::dateGroup('due_at', trans($textDueAt), 'calendar', ['id' => 'due_at', 'class' => 'form-control datepicker', 'required' => 'required', 'show-date-format' => company_date_format(), 'date-format' => 'Y-m-d', 'autocomplete' => 'off', 'min-date' => 'form.issued_at', 'min-date-dynamic' => 'min_due_date', 'data-value-min' => true], $dueAt) }}
+            {{ Form::dateGroup('due_at', trans($textDueAt), 'calendar', ['id' => 'due_at', 'class' => 'form-control datepicker', 'required' => 'required', 'show-date-format' => company_date_format(), 'period' => setting('invoice.payment_terms') , 'date-format' => 'Y-m-d', 'autocomplete' => 'off', 'min-date' => 'form.issued_at', 'min-date-dynamic' => 'min_due_date', 'data-value-min' => true], $dueAt) }}
             @else
             {{ Form::hidden('due_at', old('issued_at', $issuedAt), ['id' => 'due_at', 'v-model' => 'form.issued_at']) }}
             @endif

--- a/resources/views/partials/admin/scripts.blade.php
+++ b/resources/views/partials/admin/scripts.blade.php
@@ -5,6 +5,7 @@
 
     <script type="text/javascript">
         var company_currency_code = '{{ setting("default.currency") }}';
+        var default_payment_terms = '{{ setting("invoice.payment_terms") }}';
     </script>
     
     @stack('scripts_start')

--- a/resources/views/partials/portal/scripts.blade.php
+++ b/resources/views/partials/portal/scripts.blade.php
@@ -5,6 +5,7 @@
 
     <script type="text/javascript">
         var company_currency_code = '{{ setting("default.currency") }}';
+        var default_payment_terms = '{{ setting("invoice.payment_terms") }}';
     </script>
 
     @stack('scripts_start')


### PR DESCRIPTION
Whenever user _start date_ input was given after the previously selected _due date_ , the ui for calendar was broken. In this commits, I fixed this bug by setting up correct v-model updated with a new watcher and method. This watcher follows an object with unique property in date group component's instance for due date. It's because this property is being specifically updated by input change event in the responding blades.

Moreover, there is an enhancement regarding the date components. Now, the due date input is in sync with user's settings payment terms.

This changes applies to create and edit views for reconciliations, invoices and bills. 

**The bug:**

<img width="532" alt="Screen Shot 2021-07-08 at 10 06 03" src="https://user-images.githubusercontent.com/19210867/124877855-2ca4f100-dfd4-11eb-996f-1d93b0b3c84b.png">



**Bug Fix and Enhancement**
<img width="580" alt="Screen Shot 2021-07-08 at 09 49 13" src="https://user-images.githubusercontent.com/19210867/124875950-27df3d80-dfd2-11eb-8077-dfe99a8fbcc0.png">
<img width="704" alt="Screen Shot 2021-07-08 at 09 49 30" src="https://user-images.githubusercontent.com/19210867/124875942-257ce380-dfd2-11eb-8044-f2493974d1a1.png">
<img width="706" alt="Screen Shot 2021-07-08 at 09 49 24" src="https://user-images.githubusercontent.com/19210867/124875947-2746a700-dfd2-11eb-8530-5456552e4c73.png">

