### PR TITLE
feat: add ability to add after the profile link

### DIFF
--- a/resources/views/partials/admin/navbar.blade.php
+++ b/resources/views/partials/admin/navbar.blade.php
@@ -336,6 +336,8 @@
                                 <span>{{ trans('auth.profile') }}</span>
                             </a>
                         @endcanany
+                        
+                        @stack('navbar_profile_edit_end')
 
                         @canany(['read-auth-users', 'read-auth-roles', 'read-auth-permissions'])
                             <div class="dropdown-divider"></div>


### PR DESCRIPTION
Allows moving from image 1 to image 2 for cleaner navigation:
![image](https://user-images.githubusercontent.com/952595/125716392-9ffd5c14-c717-4fc4-ae9b-6666093fa7a4.png)
to
![image](https://user-images.githubusercontent.com/952595/125716490-21e74e0c-b051-4cf8-9dcc-aad7c372ed93.png)
