### PR TITLE
Hide duplicated search bar after bulk actions

### DIFF
--- a/resources/assets/js/components/AkauntingSearch.vue
+++ b/resources/assets/js/components/AkauntingSearch.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :id="'search-field-' + _uid" class="searh-field tags-input__wrapper js-search">
+    <div :id="'search-field-' + _uid" class="searh-field tags-input__wrapper js-search" ref="searchBar">
         <div class="tags-group" v-for="(filter, index) in filtered" :index="index">
             <span v-if="filter.option" class="el-tag el-tag--primary el-tag--small el-tag--light el-tag-option">
                 {{ filter.option }}
@@ -147,9 +147,7 @@ export default {
             default: () => [],
             description: 'List of filters'
         },
-
-        dateConfig: null
-        
+        dateConfig: null, 
     },
 
     model: {

--- a/resources/assets/js/mixins/global.js
+++ b/resources/assets/js/mixins/global.js
@@ -79,6 +79,12 @@ export default {
     },
 
     mounted() {
+        if (this.$root.$refs.searchTemp) {
+            this.$nextTick(() => {
+                this.$root.$refs.searchTemp.hidden = true;
+            })
+        }; //hides the placeholder searchbar after vue component is mounted to page.
+
         this.checkNotify();
 
         if (aka_currency) {

--- a/resources/views/components/search-string.blade.php
+++ b/resources/views/components/search-string.blade.php
@@ -1,4 +1,4 @@
-<div class="position-relative js-search-box-hidden" style="height: 48.5px;">
+<div class="position-relative" hidden style="height: 48.5px;">
     <div class="border-bottom-0 w-100 position-absolute left-0 right-0" style="z-index: 9;">
         <input type="text" placeholder="Search or filter results..." class="form-control" />
     </div>

--- a/resources/views/components/search-string.blade.php
+++ b/resources/views/components/search-string.blade.php
@@ -1,4 +1,4 @@
-<div class="position-relative" hidden style="height: 48.5px;">
+<div class="position-relative js-search-box-hidden" ref="searchTemp" style="height: 48.5px;">
     <div class="border-bottom-0 w-100 position-absolute left-0 right-0" style="z-index: 9;">
         <input type="text" placeholder="Search or filter results..." class="form-control" />
     </div>


### PR DESCRIPTION
Bug: Selecting items for bulk actions and using 'clear' event would duplicate the search fields.

<img width="1128" alt="Screen Shot 2021-09-24 at 13 40 46" src="https://user-images.githubusercontent.com/19210867/134662296-348252bd-51c6-4381-9f3c-fdd475de6713.png">

