### PR TITLE
Popover styling broken in document pages

### DIFF
--- a/resources/views/components/documents/form/totals.blade.php
+++ b/resources/views/components/documents/form/totals.blade.php
@@ -75,14 +75,14 @@
                                                 </div>
                                             </div>
                                             </div>
-                                        </div>
-                                        <div class="discount card-footer">
-                                            <div class="row float-right">
-                                                <div class="col-xs-12 col-sm-12">
-                                                    <a href="javascript:void(0)" @click="discount = false" class="btn btn-outline-secondary" @click="closePayment">
-                                                        {{ trans('general.cancel') }}
-                                                    </a>
-                                                    {!! Form::button(trans('general.save'), ['type' => 'button', 'id' => 'save-discount', '@click' => 'onAddTotalDiscount', 'class' => 'btn btn-success']) !!}
+                                            <div class="discount card-footer py-3">
+                                                <div class="row float-right">
+                                                    <div class="col-xs-12 col-sm-12">
+                                                        <a href="javascript:void(0)" @click="discount = false" class="btn btn-outline-secondary" @click="closePayment">
+                                                            {{ trans('general.cancel') }}
+                                                        </a>
+                                                        {!! Form::button(trans('general.save'), ['type' => 'button', 'id' => 'save-discount', '@click' => 'onAddTotalDiscount', 'class' => 'btn btn-success']) !!}
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
Before development
<img width="373" alt="Screen Shot 2021-09-24 at 16 09 53" src="https://user-images.githubusercontent.com/22003497/134679721-146fd1c3-00ee-4c0d-8ff3-4a6941f2e30e.png">

After development
<img width="346" alt="Screen Shot 2021-09-24 at 16 10 38" src="https://user-images.githubusercontent.com/22003497/134679745-a8bd276b-f5b1-4d00-9b98-56b5b445a0d3.png">
