### PR TITLE
Hide duplicated search bar after bulk actions

### DIFF
--- a/resources/assets/js/plugins/bulk-action.js
+++ b/resources/assets/js/plugins/bulk-action.js
@@ -39,6 +39,7 @@ export default class BulkAction {
 
         if (!this.count) {
             this.show = false;
+            this.hideSearchHTML();
         }
     }
 
@@ -46,6 +47,7 @@ export default class BulkAction {
     selectAll() {
         this.show = false;
         this.selected = [];
+        this.hideSearchHTML();
 
         if (!this.select_all) {
             this.show = true;
@@ -181,7 +183,9 @@ export default class BulkAction {
     hideSearchHTML() {
         setInterval(() => {
             const search_box_html = document.querySelector('.js-search-box-hidden');
-            search_box_html.classList.add('d-none');
+            if (search_box_html) {
+                search_box_html.classList.add('d-none');
+            }
         }, 5);
     };
 

--- a/resources/assets/js/plugins/bulk-action.js
+++ b/resources/assets/js/plugins/bulk-action.js
@@ -175,7 +175,15 @@ export default class BulkAction {
         this.show = false;
         this.select_all = false;
         this.selected = [];
+        this.hideSearchHTML();
     }
+
+    hideSearchHTML() {
+        setInterval(() => {
+            const search_box_html = document.querySelector('.js-search-box-hidden');
+            search_box_html.classList.add('d-none');
+        }, 5);
+    };
 
     // Change enabled status
     status(item_id, event, notify) {


### PR DESCRIPTION
Bug: Selecting items for bulk actions and using 'clear' event would duplicate the search fields.

<img width="1128" alt="Screen Shot 2021-09-24 at 13 40 46" src="https://user-images.githubusercontent.com/19210867/135046553-8a5ad13f-90e9-4c90-bf68-1114af52f90f.png">
