### PR TITLE
Fix a duplication of the extension when uploading files.

### DIFF
--- a/app/Traits/Uploads.php
+++ b/app/Traits/Uploads.php
@@ -142,7 +142,7 @@ trait Uploads
             $file_name = Str::limit($file_name, 110);
         }
 
-        return $file_name . '.' . $this->extension($file);
+        return $file_name;
     }
 
     /**

--- a/tests/Feature/Purchases/BillsTest.php
+++ b/tests/Feature/Purchases/BillsTest.php
@@ -6,7 +6,9 @@ use App\Exports\Purchases\Bills as Export;
 use App\Jobs\Document\CreateDocument;
 use App\Models\Document\Document;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 use Tests\Feature\FeatureTestCase;
 
 class BillsTest extends FeatureTestCase
@@ -51,6 +53,47 @@ class BillsTest extends FeatureTestCase
 
         $this->assertDatabaseHas('documents', [
             'document_number' => $request['document_number'],
+        ]);
+    }
+
+    public function testItShouldCreateBillWithAttachment()
+    {
+        Storage::fake('uploads');
+        Carbon::setTestNow(Carbon::create(2021, 05, 15));
+
+        $file = new UploadedFile(
+            base_path('public/img/empty_pages/bills.png'),
+            'bills.png',
+            'image/png',
+            null,
+            true
+        );
+
+        $request = $this->getRequest();
+        $request['attachment'] = [$file];
+
+        $this->loginAs()
+            ->post(route('bills.store'), $request)
+            ->assertStatus(200);
+
+        $this->assertFlashLevel('success');
+
+        Storage::disk('uploads')->assertExists('2021/05/15/1/bills/bills.png');
+
+        $this->assertDatabaseHas('documents', [
+            'document_number' => $request['document_number']
+        ]);
+        $this->assertDatabaseHas('mediables', [
+            'mediable_type' => Document::class,
+            'tag'           => 'attachment',
+        ]);
+        $this->assertDatabaseHas('media', [
+            'disk'           => 'uploads',
+            'directory'      => '2021/05/15/1/bills',
+            'filename'       => 'bills',
+            'extension'      => 'png',
+            'mime_type'      => 'image/png',
+            'aggregate_type' => 'image',
         ]);
     }
 


### PR DESCRIPTION
The issue appeared after this commit: https://github.com/akaunting/akaunting/commit/b11fa98e347b0a8f343c2160472a33e589f96f32#

Uploaded files are saved with their extension duplicated:
![2021-10-29_20-54](https://user-images.githubusercontent.com/7408605/139456913-496d863f-76ee-46ba-bdda-2e7b9935011d.png)
![2021-10-29_21-03](https://user-images.githubusercontent.com/7408605/139458243-036e5be1-a940-40c0-a608-9bc42c0bf63e.png)


This PR just deletes adding of the extension to the file's name. The `laravel-mediable` package handles this itself:

```php
public function getDiskPath(): string
{
    return ltrim(rtrim((string)$this->directory, '/') . '/' . ltrim((string)$this->basename, '/'), '/');
}
```

```php
public function getBasenameAttribute(): string
{
    return $this->filename . '.' . $this->extension;
}
```