### PR TITLE
Images and gifs bugfix solved in apps page

### DIFF
--- a/resources/views/modules/item/documentation.blade.php
+++ b/resources/views/modules/item/documentation.blade.php
@@ -11,7 +11,7 @@
     @include('partials.modules.bar')
 
     <div class="card">
-        <div class="card-body">
+        <div class="card-body documentation-content">
             @if ($documentation)
                 {!! $documentation->body !!}
             @else
@@ -28,6 +28,14 @@
         </div>
     </div>
 @endsection
+
+@push('stylesheet')
+    <style>
+        .documentation-content img {
+            width: 100%;
+        }
+    </style>
+@endpush
 
 @push('scripts_start')
     <script src="{{ asset('public/js/modules/apps.js?v=' . version('short')) }}"></script>


### PR DESCRIPTION
Before development
<img width="1084" alt="Screen Shot 2021-11-19 at 09 41 49" src="https://user-images.githubusercontent.com/22003497/142577532-c288ece7-9cc2-43b3-85eb-994a8ae7b6f2.png">

After development
<img width="1060" alt="Screen Shot 2021-11-19 at 09 46 08" src="https://user-images.githubusercontent.com/22003497/142577636-904b0348-5613-424a-9446-63507db04f34.png">

