### PR TITLE
debugbar show copy enabled

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -147,6 +147,7 @@ return [
                 'types' => ['SELECT'],     // // workaround ['SELECT'] only. https://github.com/barryvdh/laravel-debugbar/issues/888 ['SELECT', 'INSERT', 'UPDATE', 'DELETE']; for MySQL 5.6.3+
             ],
             'hints'             => true,    // Show hints for common mistakes
+            'show_copy'         => true,    // Show copy button next to the query
         ],
         'mail' => [
             'full_log' => false


### PR DESCRIPTION
It'll enable the copy button in the 'Queries' tab of the debugbar.

![image](https://user-images.githubusercontent.com/16224533/145169194-73e972fd-13cd-4f00-86f4-799766094311.png)
