### PR TITLE
Fix timeout

### DIFF
--- a/app/Http/Controllers/Sales/Customers.php
+++ b/app/Http/Controllers/Sales/Customers.php
@@ -26,7 +26,7 @@ class Customers extends Controller
      */
     public function index()
     {
-        $customers = Contact::with('invoices.transactions')->customer()->collect();
+        $customers = Contact::query()->customer()->collect();
 
         return $this->response('sales.customers.index', compact('customers'));
     }


### PR DESCRIPTION
When your table `document_items` has around 65k records and you try to filter invoices in view '.../sales/invoices' then the server returns a timeout error, because it selects all unnecessary dependencies for the current request.