### PR TITLE
json_encode thousands seperator so js won't break

### DIFF
--- a/app/Traits/Charts.php
+++ b/app/Traits/Charts.php
@@ -145,7 +145,7 @@ trait Charts
                     'label' => new Raw("function(tooltipItem, data) {
                         const moneySettings = {
                             decimal: '" . config('money.' . setting('default.currency') . '.decimal_mark') . "',
-                            thousands: '". config('money.' . setting('default.currency') . '.thousands_separator') . "',
+                            thousands: ". json_encode(config('money.' . setting('default.currency') . '.thousands_separator')) . ",
                             symbol: '" . config('money.' . setting('default.currency') . '.symbol') . "',
                             isPrefix: '" . config('money.' . setting('default.currency') . '.symbol_first') . "',
                             precision: '" . config('money.' . setting('default.currency') . '.precision') . "',
@@ -201,7 +201,7 @@ trait Charts
             $options['scales']['yAxes'][0]['ticks']['callback'] = new Raw("function(value, index, values) {
                             const moneySettings = {
                                 decimal: '" . config('money.' . setting('default.currency') . '.decimal_mark') . "',
-                                thousands: '". config('money.' . setting('default.currency') . '.thousands_separator') . "',
+                                thousands: ". json_encode(config('money.' . setting('default.currency') . '.thousands_separator')) . ",
                                 symbol: '" . config('money.' . setting('default.currency') . '.symbol') . "',
                                 isPrefix: '" . config('money.' . setting('default.currency') . '.symbol_first') . "',
                                 precision: '" . config('money.' . setting('default.currency') . '.precision') . "',


### PR DESCRIPTION
Before:
generates invalid JS like this:
```
const moneySettings = {
   decimal: '.',
   thousands: ''', // THIS IS INVALID
   symbol: 'CHF',
   isPrefix: '1',
   precision: '2',
};
```
Causes the "Umlaufvermögen" Chart to break in the FrontEnd on the Dashboard. (Shows infinite loading screen)

You probably also want to json_encode all the other possible settings, (or some other processing of the variable) that are patching together the JS. The `thousands` is just really susceptible to this bug because `'` is a common thousands seperator.

After:

<img width="277" alt="Screenshot 2021-12-14 at 16 14 36" src="https://user-images.githubusercontent.com/11424820/146025537-1e343836-eaf1-4a46-9509-fde3fbcc3b69.png">
