### PR TITLE
Allow using custom labels for a radio button

### DIFF
--- a/resources/views/partials/form/radio_group.blade.php
+++ b/resources/views/partials/form/radio_group.blade.php
@@ -15,24 +15,24 @@
             <div class="btn-group btn-group-toggle radio-yes-no" data-toggle="buttons">
                 @if (empty($attributes['disabled']))
                 <label class="btn btn-success" @click="form.{{ $name }}=1" v-bind:class="{ active: form.{{ $name }} == 1 }">
-                    {{ trans('general.yes') }}
+                    {{ empty($enable) ? trans('general.yes') : $enable }}
                     <input type="radio" name="{{ $name }}" id="{{ $name }}-1" v-model="{{ !empty($attributes['v-model']) ? $attributes['v-model'] : (!empty($attributes['data-field']) ? 'form.' . $attributes['data-field'] . '.'. $name : 'form.' . $name) }}">
                 </label>
                 @else
                 <label class="btn btn-success{{ ($value) ? ' active-disabled disabled' : ' disabled' }}">
-                    {{ trans('general.yes') }}
+                    {{ empty($enable) ? trans('general.yes') : $enable }}
                     <input type="radio" name="{{ $name }}" id="{{ $name }}-1" disabled>
                 </label>
                 @endif
 
                 @if (empty($attributes['disabled']))
                 <label class="btn btn-danger" @click="form.{{ $name }}=0" v-bind:class="{ active: form.{{ $name }} == 0 }">
-                    {{ trans('general.no') }}
+                    {{ empty($disable) ? trans('general.no') : $disable }}
                     <input type="radio" name="{{ $name }}" id="{{ $name }}-0" v-model="{{ !empty($attributes['v-model']) ? $attributes['v-model'] : (!empty($attributes['data-field']) ? 'form.' . $attributes['data-field'] . '.'. $name : 'form.' . $name) }}">
                 </label>
                 @else
                 <label class="btn btn-danger{{ ($value) ? ' disabled' : ' active-disabled disabled' }}">
-                    {{ trans('general.no') }}
+                    {{ empty($disable) ? trans('general.no') : $disable }}
                     <input type="radio" name="{{ $name }}" id="{{ $name }}-0" disabled>
                 </label>
                 @endif


### PR DESCRIPTION
For now, the "radio" component shows only the default "yes/no" variants regardless of passed attributes:

![2022-01-21 15-39-11 Edit Currency - Modules Testing - Google Chrome](https://user-images.githubusercontent.com/7408605/150504100-a9422cf4-8c12-4b1a-8e97-b21c6eee6cbb.png)

https://github.com/akaunting/akaunting/blob/master/resources/views/partials/form/radio_group.blade.php#L18
https://github.com/akaunting/akaunting/blob/master/resources/views/partials/form/radio_group.blade.php#L30

This PR changes the component's behavior so it will use the provided strings for labels, but will back to defaults if there are no custom labels. Thus, it won't break any existing code in the Core and modules.