### PR TITLE
Fix to show persisted select option in app settings

### DIFF
--- a/resources/views/settings/modules/edit.blade.php
+++ b/resources/views/settings/modules/edit.blade.php
@@ -26,7 +26,7 @@
                         @elseif ($type == 'textareaGroup')
                             {{ Form::$type($field['name'], trans($field['title'])) }}
                         @elseif ($type == 'selectGroup')
-                            {{ Form::$type($field['name'], trans($field['title']), $field['icon'], $field['values'], $field['selected'], $field['attributes']) }}
+                            {{ Form::$type($field['name'], trans($field['title']), $field['icon'], $field['values'], isset($setting[$field['name']]) ? $setting[$field['name']] : $field['selected'], $field['attributes']) }}
                         @elseif ($type == 'radioGroup')
                             {{ Form::$type($field['name'], trans($field['title']), isset($setting[$field['name']]) ? $setting[$field['name']] : 1, trans($field['enable']), trans($field['disable']), $field['attributes']) }}
                         @elseif ($type == 'checkboxGroup')


### PR DESCRIPTION
Fix to show persisted select option in app settings.

Example:

PayFlexi - [https://akaunting.com/apps/payflexi](https://akaunting.com/apps/payflexi)

![screenshot_settings](https://user-images.githubusercontent.com/6050573/157554359-63b110e5-26c6-4b19-a816-4cea2735c31a.png)

