### PR TITLE
Extra documents created on recurring

### DIFF
--- a/app/Console/Commands/RecurringCheck.php
+++ b/app/Console/Commands/RecurringCheck.php
@@ -101,18 +101,14 @@ class RecurringCheck extends Command
                 continue;
             }
 
-            // Recur only today
-            if ($children_count == ($schedule_count - 1)) {
-                $this->recur($model, $recur->recurable_type, $today);
-
-                continue;
-            }
-
-            // Recur all schedules, previously failed
+            // Recur all schedules that don´t already exist
             foreach ($schedules as $schedule) {
                 $schedule_date = Date::parse($schedule->getStart()->format('Y-m-d'));
-
-                $this->recur($model, $recur->recurable_type, $schedule_date);
+                $today_date = Date::parse($today->format('Y-m-d'));
+                $recurAlreadyExists = $this->skipThisClone($model, $today_date) || $this->skipThisClone($model, $schedule_date);
+                if (!$recurAlreadyExists) {
+                    $this->recur($model, $recur->recurable_type, $schedule_date);
+                }
             }
         }
 


### PR DESCRIPTION
[-] The two calls to recur with different dates cause skipThisClone to be called each time, which will return false in one of them (unless there are both clones, one for each date, which doesn't make much sense). This creates extra clones. Now all the schedules are traversed and recur is called for those that do not already have a clone on one of the two dates.