### PR TITLE
Ejected resize-none from descirpiton input in document form

### DIFF
--- a/resources/views/components/documents/form/line-item.blade.php
+++ b/resources/views/components/documents/form/line-item.blade.php
@@ -65,7 +65,7 @@
                         <td class="px-3 py-3 border-b-0 description">
                             @if (! $hideItemDescription)
                                 <textarea
-                                    class="form-element mt-1.5 resize-none"
+                                    class="form-element mt-1.5"
                                     style="height:42px;"
                                     :ref="'items-' + index + '-description'"
                                     placeholder="{{ trans('items.enter_item_description') }}"


### PR DESCRIPTION
If item description text of item, texts couldn't appear.
<img width="949" alt="Screen Shot 2022-06-15 at 11 06 55" src="https://user-images.githubusercontent.com/22003497/173776016-d2c392a1-c4e5-4ed1-a668-24d3ccb35b87.png">
