### PR TITLE
fix: show module information error

### DIFF
--- a/resources/views/components/layouts/modules/show/information.blade.php
+++ b/resources/views/components/layouts/modules/show/information.blade.php
@@ -6,6 +6,7 @@
             {!! trans('modules.only_premium_plan') !!}
         </span>
     </div>
+@endif
 @elseif (in_array('onprime', $module->where_to_use))
     <div x-show="price_type == true" class="text-center text-sm mt-3 mb--2">
         <span style="height: 21px;display: block;"></span>


### PR DESCRIPTION
When you try to open module information, it shows a 500 internal error. If you try to debug, it shows a minor syntax problem that  the if branch is not closed with endif.