### PR TITLE
Loading controlled  for show page

### DIFF
--- a/resources/views/components/loading/absolute.blade.php
+++ b/resources/views/components/loading/absolute.blade.php
@@ -1,4 +1,4 @@
-<div data-absolute-loading-content v-if="content_loading" class="absolute w-full lg:flex items-center justify-center bg-body top-0 bottom-0 left-0 right-0 z-50">
+<div data-absolute-loading-content v-if="content_loading" class="absolute w-full lg:flex items-start justify-center bg-body top-0 bottom-0 left-0 right-0 z-50">
   <img src="{{ asset('public/img/akaunting-loading.gif') }}" class="w-28 h-28" alt="Akaunting" />
 </div>
 <!--data attr added because for none vue.js pages-->


### PR DESCRIPTION
If there is long data, spin couldn’t appear, fixed this issue.