### PR TITLE
Fixed exception: Property [contact_id] does not exist

### DIFF
--- a/app/View/Components/Form/Group/Contact.php
+++ b/app/View/Components/Form/Group/Contact.php
@@ -39,7 +39,7 @@ class Contact extends Form
 
         $model = $this->getParentData('model');
 
-        if (! empty($model)) {
+        if (! empty($model) && property_exists($model, 'contact_id')) {
             $this->selected = $model->contact_id;
 
             if (! $this->contacts->has($model->contact_id) && ($contact = $model->contact)) {


### PR DESCRIPTION
Laravel Log:
```log
[previous exception] [object] (Exception(code: 0): Property [contact_id] does not exist on this collection instance. at /akaunting30/vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php:983)
[stacktrace]
#0 /akaunting30/app/View/Components/Form/Group/Contact.php(43): Illuminate\\Support\\Collection->__get()
#1 /akaunting30/vendor/laravel/framework/src/Illuminate/View/Component.php(64): App\\View\\Components\\Form\\Group\\Contact->render()
```