### PR TITLE
Uses locale config from env while install

### DIFF
--- a/app/Http/Controllers/Install/Language.php
+++ b/app/Http/Controllers/Install/Language.php
@@ -14,7 +14,11 @@ class Language extends Controller
      */
     public function create()
     {
-        return view('install.language.create');
+        $locale = config('app.locale');
+        if (!$locale || !array_key_exists($locale, language()->allowed())) {
+            $locale = 'en-GB';
+        }
+        return view('install.language.create')->with(['locale' => $locale]);
     }
 
     /**

--- a/app/Http/Controllers/Install/Language.php
+++ b/app/Http/Controllers/Install/Language.php
@@ -15,10 +15,14 @@ class Language extends Controller
     public function create()
     {
         $locale = config('app.locale');
-        if (!$locale || !array_key_exists($locale, language()->allowed())) {
+
+        $lang_allowed = language()->allowed();
+
+        if (! $locale || ! array_key_exists($locale, $lang_allowed)) {
             $locale = 'en-GB';
         }
-        return view('install.language.create')->with(['locale' => $locale]);
+
+        return view('install.language.create', compact('locale', 'lang_allowed'));
     }
 
     /**

--- a/app/Http/Controllers/Install/Settings.php
+++ b/app/Http/Controllers/Install/Settings.php
@@ -29,11 +29,13 @@ class Settings extends Controller
     public function store(Request $request)
     {
         DB::transaction(function () use ($request) {
+            $locale = session('locale') ?? config('app.locale');
+
             // Create company
-            Installer::createCompany($request->get('company_name'), $request->get('company_email'), session('locale'));
+            Installer::createCompany($request->get('company_name'), $request->get('company_email'), $locale);
 
             // Create user
-            Installer::createUser($request->get('user_email'), $request->get('user_password'), session('locale'));
+            Installer::createUser($request->get('user_email'), $request->get('user_password'), $locale);
         });
 
         // Make the final touches

--- a/resources/views/install/language/create.blade.php
+++ b/resources/views/install/language/create.blade.php
@@ -7,7 +7,7 @@
         <div class="mb-0">
             <select name="lang" id="lang" size="14" class="w-full text-black text-sm font-medium">
                 @foreach (language()->allowed() as $code => $name)
-                <option value="{{ $code }}" @if ($code=='en-GB' ) {{ 'selected="selected"' }} @endif>{{ $name }}</option>
+                <option value="{{ $code }}" @if ($code == $locale) {{ 'selected="selected"' }} @endif>{{ $name }}</option>
                 @endforeach
             </select>
         </div>

--- a/resources/views/install/language/create.blade.php
+++ b/resources/views/install/language/create.blade.php
@@ -6,7 +6,7 @@
     <x-slot name="content">
         <div class="mb-0">
             <select name="lang" id="lang" size="14" class="w-full text-black text-sm font-medium">
-                @foreach (language()->allowed() as $code => $name)
+                @foreach ($lang_allowed as $code => $name)
                 <option value="{{ $code }}" @if ($code == $locale) {{ 'selected="selected"' }} @endif>{{ $name }}</option>
                 @endforeach
             </select>


### PR DESCRIPTION
Currently it is impossible to load database config values from env file
Also, if user is not coming from `install/language` then locale is missing in session