### PR TITLE
Fix: Download file should be possible regardless delete permissions.

### DIFF
--- a/resources/views/components/media/file.blade.php
+++ b/resources/views/components/media/file.blade.php
@@ -14,15 +14,15 @@
         @can('delete-common-uploads')
             <a href="javascript:void();" id="remove-{{ $column_name }}" @click="onDeleteFile('{{ $file->id }}', '{{ route('uploads.destroy', $file->id) }}', '{{ trans('general.title.delete', ['type' => $column_name]) }}', '{{ trans('general.delete_confirm', ['name' => $file->basename, 'type' => $column_name]) }} ', '{{ trans('general.cancel') }}', '{{ trans('general.delete') }}')" type="button" class="group">
                 <span class="material-icons text-base text-red px-1.5 py-1 rounded-lg group-hover:bg-gray-100">delete</span>
-            </a>    
-            @if ($options)
-                <input type="hidden" name="page_{{ $file->id}}" id="file-page-{{ $file->id}}" value="{{ $options['page'] }}" />
-                <input type="hidden" name="key_{{ $file->id}}" id="file-key-{{ $file->id}}" value="{{ $options['key'] }}" />
-                <input type="hidden" name="value_{{ $file->id}}" id="file-value-{{ $file->id}}" value="{{ $file->id }}" />
-            @endif  
-            <a href="{{ route('uploads.download', $file->id) }}" type="button" class="group">
-                <span class="material-icons text-base text-purple px-1.5 py-1 rounded-lg group-hover:bg-gray-100">download</span>
             </a>
         @endcan
+        @if ($options)
+            <input type="hidden" name="page_{{ $file->id}}" id="file-page-{{ $file->id}}" value="{{ $options['page'] }}" />
+            <input type="hidden" name="key_{{ $file->id}}" id="file-key-{{ $file->id}}" value="{{ $options['key'] }}" />
+            <input type="hidden" name="value_{{ $file->id}}" id="file-value-{{ $file->id}}" value="{{ $file->id }}" />
+        @endif  
+        <a href="{{ route('uploads.download', $file->id) }}" type="button" class="group">
+            <span class="material-icons text-base text-purple px-1.5 py-1 rounded-lg group-hover:bg-gray-100">download</span>
+        </a>
     </div>
 </div>


### PR DESCRIPTION
Currently the "delete-common-uploads" permissions are blocking the possibility to download an attached file for a user who does not have "delete" permissions. It is proposed to limit the effect of this limitation to the "delete" action, allowing to donwload the file.