### PR TITLE
Fix: Use proper translations from module in Portal

### DIFF
--- a/app/View/Components/EmptyPage.php
+++ b/app/View/Components/EmptyPage.php
@@ -82,6 +82,9 @@ class EmptyPage extends Component
             $alias = $group;
         }
 
+        // Remove 'portal.' to correctly detect the module name when called form Portal
+        $alias = preg_replace('/portal\./', '', $alias);
+
         $this->alias = (module($alias) === null) ? 'core': $alias;
         $this->group = $group;
         $this->page = $page;


### PR DESCRIPTION
Module translations in Portal page for the Empty page (when no records in the module have been created yet) are not correct. The problem is that inside the EmptyPage.php file the module is detected as "portal.modulename" and translations are not found. I propose to remove the "portal." section of the $alias so that the module is correctly detected and the proper translations are used.
I detected this problem through Helpdesk module, which is used in Portal, however it should be tested with other modules to ensure the proposed fix works for all of them.