### PR TITLE
Tooltip appear in Dashboard title

### DIFF
--- a/resources/views/components/title.blade.php
+++ b/resources/views/components/title.blade.php
@@ -1,4 +1,8 @@
-@if (strlen($slot) >= 25 )
+@php
+    $slot_isHtml = strlen(strip_tags($slot)) < strlen($slot);
+@endphp
+
+@if (strlen($slot) >= 25 && $slot_isHtml != true)
     <x-tooltip id="page-title" placement="bottom" message="{!! $slot !!}">
         <div class="truncate" style="width: 22rem;">
             {!! $slot !!}


### PR DESCRIPTION
If you have multiple dashboard, tooltip appear. I fixed this issue.

**Before development:**
<img width="1075" alt="Screen Shot 2022-08-24 at 10 31 44" src="https://user-images.githubusercontent.com/22003497/186358609-fa5fea20-4ff5-4b53-94aa-f6bcd75b2fd4.png">

**After development**
<img width="1105" alt="Screen Shot 2022-08-24 at 10 32 02" src="https://user-images.githubusercontent.com/22003497/186358657-5fb85456-56ea-4a8c-8ce1-d40ffe1edd49.png">
