### PR TITLE
Show correct date for sent recurring invoices 

### DIFF
--- a/resources/views/components/documents/show/children.blade.php
+++ b/resources/views/components/documents/show/children.blade.php
@@ -14,7 +14,7 @@
                 @endphp
 
                 <div class="my-2">
-                    {!! trans('recurring.child', ['url' => $url, 'date' => company_date($child->due_at)]) !!}
+                    {!! trans('recurring.child', ['url' => $url, 'date' => company_date($child->created_at)]) !!}
                 </div>
             @endforeach
         @else


### PR DESCRIPTION
Shows the date when the invoice was actually sent instead of the due date.
Fixes issue #2628