### PR TITLE
Added white space into the status for Show page

### DIFF
--- a/resources/views/components/show/status.blade.php
+++ b/resources/views/components/show/status.blade.php
@@ -1,5 +1,5 @@
 <span @class([
-        'px-2.5 py-1 text-xs font-medium rounded-xl',
+        'px-2.5 py-1 text-xs font-medium rounded-xl whitespace-nowrap',
         $backgroundColor,
         $textColor,
     ])


### PR DESCRIPTION
Probably broken after the last developments. Fixed this issue.

Before development
<img width="967" alt="Screen Shot 2022-11-22 at 12 29 39" src="https://user-images.githubusercontent.com/22003497/203277575-d84d869f-b774-4f40-be69-f454ed7cbcaf.png">

After development
<img width="962" alt="Screen Shot 2022-11-22 at 12 29 26" src="https://user-images.githubusercontent.com/22003497/203277615-335336fc-8394-495e-8f0d-a67e55f2ab00.png">
