### PR TITLE
Unused styling strokes ejected from Modals

### DIFF
--- a/resources/assets/js/components/AkauntingConnectTransactions.vue
+++ b/resources/assets/js/components/AkauntingConnectTransactions.vue
@@ -8,8 +8,8 @@
             :aria-hidden="!show">
             <div class="w-full my-10 m-auto flex flex-col" :class="modalDialogClass ? modalDialogClass : 'max-w-screen-sm'">
                 <slot name="modal-content">
-                    <div class="modal-content">
-                        <div class="p-5 bg-body rounded-tl-lg rounded-tr-lg">
+                    <div class="bg-body rounded-lg modal-content">
+                        <div class="p-5">
                             <div class="flex items-center justify-between border-b pb-5">
                                 <slot name="card-header">
                                     <h4 class="text-base font-medium">
@@ -24,7 +24,7 @@
                         </div>
 
                         <slot name="modal-body">
-                            <div class="px-5 bg-body">
+                            <div class="px-5">
                                 <template v-if="transaction">
                                     <div class="flex flex-col items-start gap-y-3">
                                         <div class="text-left text-sm">
@@ -247,7 +247,7 @@
                             </div>
                         </slot>
 
-                        <div class="p-5 bg-body rounded-bl-lg rounded-br-lg border-gray-300">
+                        <div class="p-5 border-gray-300">
                             <slot name="card-footer">
                                 <div class="flex items-center justify-end">
                                     <button type="button" class="px-6 py-1.5 mr-2 hover:bg-gray-200 rounded-lg" @click="onCancel">

--- a/resources/assets/js/components/AkauntingModal.vue
+++ b/resources/assets/js/components/AkauntingModal.vue
@@ -29,7 +29,7 @@
                             <div class="py-1 px-5" v-html="message"></div>
                         </slot>
 
-                        <div class="p-5 rounded-bl-lg rounded-br-lg border-gray-300">
+                        <div class="p-5 border-gray-300">
                             <slot name="card-footer">
                                 <div class="flex items-center justify-end">
                                     <button type="button" class="px-6 py-1.5 ltr:mr-2 rtl:ml-2 hover:bg-gray-200 rounded-lg" @click="onCancel">

--- a/resources/assets/js/components/AkauntingModal.vue
+++ b/resources/assets/js/components/AkauntingModal.vue
@@ -10,8 +10,8 @@
             :aria-hidden="!show">
             <div class="w-full my-10 m-auto flex flex-col px-2 sm:px-0" :class="modalDialogClass ? modalDialogClass : 'max-w-md'">
                 <slot name="modal-content">
-                    <div class="modal-content">
-                        <div class="p-5 bg-body rounded-tl-lg rounded-tr-lg">
+                    <div class="bg-body rounded-lg modal-content">
+                        <div class="p-5">
                             <div class="flex items-center justify-between border-b pb-5">
                                 <slot name="card-header">
                                     <h4 class="text-base font-medium">
@@ -26,10 +26,10 @@
                         </div>
 
                         <slot name="modal-body">
-                            <div class="py-1 px-5 bg-body" v-html="message"></div>
+                            <div class="py-1 px-5" v-html="message"></div>
                         </slot>
 
-                        <div class="p-5 bg-body rounded-bl-lg rounded-br-lg border-gray-300">
+                        <div class="p-5 rounded-bl-lg rounded-br-lg border-gray-300">
                             <slot name="card-footer">
                                 <div class="flex items-center justify-end">
                                     <button type="button" class="px-6 py-1.5 ltr:mr-2 rtl:ml-2 hover:bg-gray-200 rounded-lg" @click="onCancel">

--- a/resources/assets/js/components/AkauntingModalAddNew.vue
+++ b/resources/assets/js/components/AkauntingModalAddNew.vue
@@ -10,8 +10,8 @@
             :aria-hidden="!show">
             <div class="w-full my-10 m-auto flex flex-col px-2 sm:px-0" :class="modalDialogClass ? modalDialogClass : 'max-w-md'">
                 <slot name="modal-content">
-                    <div class="modal-content">
-                        <div class="p-5 bg-body rounded-tl-lg rounded-tr-lg">
+                    <div class="bg-body rounded-lg modal-content">
+                        <div class="p-5">
                             <div class="flex items-center justify-between border-b pb-5">
                                 <slot name="card-header">
                                     <h4 class="text-base font-medium">
@@ -26,15 +26,15 @@
                         </div>
 
                         <slot name="modal-body">
-                            <div class="py-1 px-5 bg-body" v-if="!is_component" v-html="message"></div>
-                            <div class="py-1 px-5 bg-body" v-else>
+                            <div class="py-1 px-5" v-if="!is_component" v-html="message"></div>
+                            <div class="py-1 px-5" v-else>
                                 <form id="form-create" method="POST" action="#"/>
 
                                 <component v-bind:is="component"></component>
                             </div>
                         </slot>
 
-                        <div class="p-5 bg-body rounded-bl-lg rounded-br-lg border-gray-300">
+                        <div class="p-5 border-gray-300">
                             <slot name="card-footer">
                                 <div class="flex items-center justify-end">
                                     <button type="button" class="px-6 py-1.5 mr-2 hover:bg-gray-200 rounded-lg" :class="buttons.cancel.class" @click="onCancel">


### PR DESCRIPTION
When mobile environment modal have extra stroke. Fixed this issue.

Before development
<img width="293" alt="Screen Shot 2022-11-25 at 15 16 00" src="https://user-images.githubusercontent.com/22003497/203984389-3e6dac53-6b0a-4a6e-860b-a9c98df93c32.png">

After development
<img width="330" alt="Screen Shot 2022-11-25 at 15 13 26" src="https://user-images.githubusercontent.com/22003497/203984405-74794a59-8bd7-4ab5-bed6-8a0391a0cef6.png">
