### PR TITLE
Added spacing for head buttons

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -53413,6 +53413,7 @@ button, input, optgroup, select, textarea{
 }
 .suggestion-buttons a, .suggestion-buttons button{
   margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 [data-dropdown-actions] {
         -webkit-transform: unset !important;
@@ -57155,11 +57156,6 @@ body{
   .sm\:text-6xl{
     font-size: 2.5rem;
     line-height: 2.75rem;
-  }
-
-  .sm\:text-sm{
-    font-size: 0.875rem;
-    line-height: 1.25rem;
   }
 
   .sm\:text-purple{

--- a/resources/assets/sass/app.css
+++ b/resources/assets/sass/app.css
@@ -23,7 +23,7 @@
     }
 
     .suggestion-buttons a, .suggestion-buttons button {
-        @apply mt-2;
+        @apply mt-2 mb-2;
     }
 
     [data-dropdown-actions] {


### PR DESCRIPTION
Probably button alignment broken at previous development. Fixed this issue.

Before development
<img width="398" alt="Screen Shot 2022-12-01 at 11 22 27" src="https://user-images.githubusercontent.com/22003497/205002533-f6f26a70-9f43-4f24-8cfc-8d2293891a4f.png">

After development
<img width="401" alt="Screen Shot 2022-12-01 at 11 22 11" src="https://user-images.githubusercontent.com/22003497/205002569-30ea5632-c9f9-4868-b8cd-9947df3a4788.png">
