### PR TITLE
The flash value appear in the description.

### DIFF
--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -59,6 +59,6 @@ abstract class FeatureTestCase extends TestCase
             $flash = $flashMessage->first();
         }
 
-        $this->assertEquals($excepted, $flash['level']);
+        $this->assertEquals($excepted, $flash['level'], json_encode($flash));
     }
 }


### PR DESCRIPTION
When the expected level did not match the incoming level.