### PR TITLE
Javascript console error fixed

### DIFF
--- a/public/akaunting-js/generalAction.js
+++ b/public/akaunting-js/generalAction.js
@@ -190,37 +190,40 @@ function runDropdown(dropdownToggleEl) {
         ],
     }); // toggle when click on the button
 
-    dropdownMenuEl.classList.toggle("hidden");
-    dropdownMenuEl.classList.toggle("block");
+    if (dropdownMenuEl !== null) {
+        dropdownMenuEl.classList.toggle("hidden");
+        dropdownMenuEl.classList.toggle("block");
 
-    function handleDropdownOutsideClick(event) {
-        var targetElement = event.target; // clicked element
-
-        if (
-            targetElement !== dropdownMenuEl &&
-            targetElement !== dropdownToggleEl &&
-            !dropdownToggleEl.contains(targetElement)
-        ) {
-            dropdownMenuEl.classList.add("hidden");
-            dropdownMenuEl.classList.remove("block");
-            document.body.removeEventListener(
-                "click",
-                handleDropdownOutsideClick,
-                true
-            );
+        function handleDropdownOutsideClick(event) {
+            var targetElement = event.target; // clicked element
+    
+            if (
+                targetElement !== dropdownMenuEl &&
+                targetElement !== dropdownToggleEl &&
+                !dropdownToggleEl.contains(targetElement)
+            ) {
+                dropdownMenuEl.classList.add("hidden");
+                dropdownMenuEl.classList.remove("block");
+                document.body.removeEventListener(
+                    "click",
+                    handleDropdownOutsideClick,
+                    true
+                );
+            }
+        } // hide popper when clicking outside the element
+    
+        document.body.addEventListener("click", handleDropdownOutsideClick, true);
+    
+        if (dropdownMenuEl.getAttribute("data-click-outside-none") != null) {
+            if (event.target.getAttribute("data-click-outside") != null || event.target.parentElement.getAttribute("data-click-outside") != null) {
+                dropdownMenuEl.classList.add("hidden");
+                dropdownMenuEl.classList.remove("block");
+                return;
+            }
+            debugger;
+            dropdownMenuEl.classList.add("block");
+            dropdownMenuEl.classList.remove("hidden");
         }
-    } // hide popper when clicking outside the element
-
-    document.body.addEventListener("click", handleDropdownOutsideClick, true);
-
-    if (dropdownMenuEl.getAttribute("data-click-outside-none") != null) {
-        if (event.target.getAttribute("data-click-outside") != null || event.target.parentElement.getAttribute("data-click-outside") != null) {
-            dropdownMenuEl.classList.add("hidden");
-            dropdownMenuEl.classList.remove("block");
-            return;
-        }
-        dropdownMenuEl.classList.add("block");
-        dropdownMenuEl.classList.remove("hidden");
     }
 }
 // Toggle dropdown elements using [data-dropdown-toggle]

--- a/resources/assets/js/views/common/documents.js
+++ b/resources/assets/js/views/common/documents.js
@@ -113,8 +113,8 @@ const app = new Vue({
     methods: {
         onRefFocus(ref) {
             let index = this.form.items.length - 1;
-
-            if (this.$refs['items-' + index + '-' + ref] != undefined) {
+            
+            if (typeof (this.$refs['items-' + index + '-' + ref]) !== 'undefined') {
                 let first_ref = this.$refs['items-' + index + '-'  + ref];
                 first_ref != undefined ? first_ref[0].focus() : this.$refs[Object.keys(this.$refs)[0]][0].focus();
             }


### PR DESCRIPTION
When use dropdown if you don’t use dropdown id, there is javascript error. Fixed this issue.
TypeError: Cannot read properties of undefined (reading 'classList')

Also fixed this error
TypeError: Cannot read properties of undefined (reading 'this.$refs['items-' + index + '-' + ref].')