### PR TITLE
Disable control for parent category input

### DIFF
--- a/resources/assets/js/views/settings/categories.js
+++ b/resources/assets/js/views/settings/categories.js
@@ -30,6 +30,7 @@ const app = new Vue({
             form: new Form('category'),
             bulk_action: new BulkAction('categories'),
             categoriesBasedTypes: null,
+            selected_type: true
         }
     },
 
@@ -50,6 +51,8 @@ const app = new Vue({
 
                 return;
             }
+
+            this.selected_type = false;
 
             this.categoriesBasedTypes = JSON.parse(this.form.categories)[event];
         }

--- a/resources/views/settings/categories/create.blade.php
+++ b/resources/views/settings/categories/create.blade.php
@@ -24,7 +24,7 @@
 
                         <x-form.group.select name="type" label="{{ trans_choice('general.types', 1) }}" :options="$types" :selected="config('general.types')" change="updateParentCategories" />
 
-                        <x-form.group.select name="parent_id" label="{{ trans('general.parent') . ' ' . trans_choice('general.categories', 1) }}" :options="[]" not-required dynamicOptions="categoriesBasedTypes" sort-options="false" />
+                        <x-form.group.select name="parent_id" label="{{ trans('general.parent') . ' ' . trans_choice('general.categories', 1) }}" :options="[]" not-required dynamicOptions="categoriesBasedTypes" sort-options="false" v-disabled="selected_type" />
 
                         <x-form.input.hidden name="categories" value="{{ json_encode($categories) }}" />
                     </x-slot>


### PR DESCRIPTION
Parent category input is disabled. If select type, this input will open on category page.