### PR TITLE
Sort error fixed from widget component.

### DIFF
--- a/resources/assets/js/components/AkauntingWidget.vue
+++ b/resources/assets/js/components/AkauntingWidget.vue
@@ -273,6 +273,10 @@ export default {
             } else {
                 documentClasses.remove('overflow-y-hidden', 'overflow-overlay');
             }
+        },
+
+        'form.sort': function (val) {
+            this.form.sort = Number(val);
         }
     }
 }


### PR DESCRIPTION
If enter number value into the sort input in widget modal, you get error. Fixed this issue.