### PR TITLE
use the correct translation for cancellations

### DIFF
--- a/app/BulkActions/Purchases/Bills.php
+++ b/app/BulkActions/Purchases/Bills.php
@@ -31,7 +31,7 @@ class Bills extends BulkAction
         ],
         'cancelled' => [
             'icon'          => 'cancel',
-            'name'          => 'general.cancel',
+            'name'          => 'bills.mark_cancelled',
             'message'       => 'bulk_actions.message.cancelled',
             'permission'    => 'update-purchases-bills',
         ],

--- a/app/BulkActions/Sales/Invoices.php
+++ b/app/BulkActions/Sales/Invoices.php
@@ -31,7 +31,7 @@ class Invoices extends BulkAction
         ],
         'cancelled' => [
             'icon'          => 'cancel',
-            'name'          => 'general.cancel',
+            'name'          => 'invoices.mark_cancelled',
             'message'       => 'bulk_actions.message.cancelled',
             'permission'    => 'update-sales-invoices',
         ],

--- a/app/Models/Document/Document.php
+++ b/app/Models/Document/Document.php
@@ -614,7 +614,7 @@ class Document extends Model
             if ($this->status != 'cancelled') {
                 try {
                     $actions[] = [
-                        'title' => trans('general.cancel'),
+                        'title' => trans('documents.actions.mark_cancelled'),
                         'icon' => 'cancel',
                         'url' => route($prefix . '.cancelled', $this->id),
                         'permission' => 'update-' . $group . '-' . $permission_prefix,

--- a/resources/lang/en-GB/documents.php
+++ b/resources/lang/en-GB/documents.php
@@ -10,6 +10,10 @@ return [
     'billing'                   => 'Billing',
     'advanced'                  => 'Advanced',
 
+    'actions' => [
+        'mark_cancelled'        => 'Mark Cancelled',
+    ],
+
     'invoice_detail' => [
         'marked'                => '<b>You</b> marked this invoice as',
         'services'              => 'Services',

--- a/resources/views/components/documents/show/more-buttons.blade.php
+++ b/resources/views/components/documents/show/more-buttons.blade.php
@@ -114,7 +114,7 @@
 
                 @if ($document->status != 'cancelled')
                     <x-dropdown.link href="{{ route($cancelledRoute, $document->id) }}" id="show-more-actions-cancel-{{ $document->type }}">
-                        {{ trans('general.cancel') }}
+                        {{ trans('documents.actions.mark_cancelled') }}
                     </x-dropdown.link>
                 @endif
             @endcan


### PR DESCRIPTION
Some languages have different words for cancelling an action vs cancelling an invoice. Currently, the label for cancelling an invoice is very confusing in those languages.

Also, it probably makes more sense to call the button "Mark Cancelled" anyway, as a real cancellation process usually involves several actions, whereas the button only sets the status.

It might make sense to move "mark_cancelled" string to the general category instead of spreading it over bills, invoices and documents. What do the maintainers think?