### PR TITLE
use the correct translation for cancellations

### DIFF
--- a/app/BulkActions/Purchases/Bills.php
+++ b/app/BulkActions/Purchases/Bills.php
@@ -31,7 +31,7 @@ class Bills extends BulkAction
         ],
         'cancelled' => [
             'icon'          => 'cancel',
-            'name'          => 'general.cancel',
+            'name'          => 'documents.actions.cancel',
             'message'       => 'bulk_actions.message.cancelled',
             'permission'    => 'update-purchases-bills',
         ],

--- a/app/BulkActions/Sales/Invoices.php
+++ b/app/BulkActions/Sales/Invoices.php
@@ -31,7 +31,7 @@ class Invoices extends BulkAction
         ],
         'cancelled' => [
             'icon'          => 'cancel',
-            'name'          => 'general.cancel',
+            'name'          => 'documents.actions.cancel',
             'message'       => 'bulk_actions.message.cancelled',
             'permission'    => 'update-sales-invoices',
         ],

--- a/app/Models/Document/Document.php
+++ b/app/Models/Document/Document.php
@@ -614,7 +614,7 @@ class Document extends Model
             if (! in_array($this->status, ['cancelled', 'draft'])) {
                 try {
                     $actions[] = [
-                        'title' => trans('general.cancel'),
+                        'title' => trans('documents.actions.cancel'),
                         'icon' => 'cancel',
                         'url' => route($prefix . '.cancelled', $this->id),
                         'permission' => 'update-' . $group . '-' . $permission_prefix,

--- a/resources/lang/en-GB/documents.php
+++ b/resources/lang/en-GB/documents.php
@@ -10,6 +10,10 @@ return [
     'billing'                   => 'Billing',
     'advanced'                  => 'Advanced',
 
+    'actions' => [
+        'cancel'                => 'Cancel',
+    ],
+
     'invoice_detail' => [
         'marked'                => '<b>You</b> marked this invoice as',
         'services'              => 'Services',

--- a/resources/views/components/documents/show/more-buttons.blade.php
+++ b/resources/views/components/documents/show/more-buttons.blade.php
@@ -113,7 +113,7 @@
                 <x-dropdown.divider />
 
                 <x-dropdown.link href="{{ route($cancelledRoute, $document->id) }}" id="show-more-actions-cancel-{{ $document->type }}">
-                    {{ trans('general.cancel') }}
+                    {{ trans('documents.actions.cancel') }}
                 </x-dropdown.link>
             @endcan
         @endif


### PR DESCRIPTION
Some languages have different words for cancelling an action vs cancelling an invoice. Currently, the label for cancelling an invoice is very confusing in those languages.

This pull request introduces a separate string for the action 'cancel invoice/bill'.

The 'mark_cancelled' strings in 'lang/.../bills.php' and 'lang/.../invoices.php' may have been introduced earlier for this purpose. In the meantime, however, the buttons use the generic "cancel" string, which is why the problem occurs.

Ref.: #2868 was closed by mistake.
