### PR TITLE
check media existence considering the disk

### DIFF
--- a/app/Traits/Uploads.php
+++ b/app/Traits/Uploads.php
@@ -112,7 +112,7 @@ trait Uploads
 
         $path = $media->getDiskPath();
 
-        if (Storage::missing($path)) {
+        if (Storage::disk($media->disk)->missing($path)) {
             return false;
         }
 


### PR DESCRIPTION
Fixes downloads for media entries located on a disk other than the one specified in the FILESYSTEM_DISK environment variable.

This allows modules to manage media data on their own disks.

The 'allowed_disks' list specified in the mediable configuration still applies. (https://github.com/akaunting/akaunting/blob/master/config/mediable.php#L26)