### PR TITLE
fix 'description' field stack names in line item form

### DIFF
--- a/resources/views/components/documents/form/items.blade.php
+++ b/resources/views/components/documents/form/items.blade.php
@@ -15,6 +15,7 @@
                 <thead class="border-b">
                     <tr>
                         @stack('move_th_start')
+
                         <th class="w-6 block text-left border-t-0 border-r-0 border-b-0" style="vertical-align:bottom;">
                             @if (! $hideEditItemColumns)
                                 <x-documents.form.item-columns :type="$type" />
@@ -31,11 +32,10 @@
                                         {{ (trans_choice($textItemName, 2) != $textItemName) ? trans_choice($textItemName, 2) : trans($textItemName) }}
                                     @endif
                                 </th>
-                            
 
                             @stack('name_th_end')
 
-                            @stack('move_th_start')
+                            @stack('description_th_start')
 
                             <th class="px-3 py-1 text-left text-xs font-normal border-t-0 border-r-0 border-b-0" style=" vertical-align:bottom;">
                                 @if (! $hideItemDescription)
@@ -43,8 +43,7 @@
                                 @endif
                             </th>
                             
-
-                            @stack('move_th_end')
+                            @stack('description_th_end')
                         @endif
 
                         @stack('quantity_th_start')
@@ -54,7 +53,6 @@
                                 {{ trans($textItemQuantity) }}
                             @endif
                         </th>
-                        
 
                         @stack('quantity_th_end')
 

--- a/resources/views/components/documents/form/line-item.blade.php
+++ b/resources/views/components/documents/form/line-item.blade.php
@@ -19,17 +19,20 @@
                 <tbody>
                     <tr>
                         @stack('move_td_start')
+
                         <td class="align-middle border-b-0 flex items-center justify-center" style="width:24px; height:100px; color: #8898aa;">
                             <div class="handle mt-2 hidden lg:block cursor-move">
                                 <span class="w-6 material-icons">list</span>
                             </div>
                         </td>
+
                         @stack('move_td_end')
 
                         @stack('items_td_start')
 
                         @if (! $hideItems || (! $hideItemName && ! $hideItemDescription))
                             @stack('name_td_start')
+
                             <td class="px-3 py-3 ltr:pl-2 rtl:pr-2 ltr:text-left rtl:text-right align-middle border-b-0 name">
                                 @if (! $hideItemName)
                                     <span class="flex items-center text-sm" tabindex="0" v-if="row.item_id">


### PR DESCRIPTION
The start/end stacks of the description header field were incorrectly named.

Additionally fixed some newline format errors.