### PR TITLE
remove rate_limit option in api config

### DIFF
--- a/config/api.php
+++ b/config/api.php
@@ -156,20 +156,4 @@ return [
     */
 
     'middleware' => explode(',', env('API_MIDDLEWARE', 'api')),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Rate Limit (Throttle)
-    |--------------------------------------------------------------------------
-    |
-    | Consumers of your API can be limited to the amount of requests they can
-    | make. You can create your own throttles or simply change the default
-    | throttles.
-    |
-    */
-
-    'rate_limit' => [
-        Limit::perMinute(env('API_RATE_LIMIT', 60)),
-    ],
-
 ];


### PR DESCRIPTION
Since, the option is not used anywhere and will cause error when running `php artisan optimize` 
```bash
LogicException 

Your configuration files are not serializable.
```

![image](https://user-images.githubusercontent.com/21292986/221282648-b36b6245-b55e-4700-be35-8ce3caaddd2d.png)
