### PR TITLE
allow hooking functions related to document numbers

### DIFF
--- a/app/Traits/Documents.php
+++ b/app/Traits/Documents.php
@@ -5,6 +5,7 @@ namespace App\Traits;
 use App\Models\Document\Document;
 use App\Abstracts\View\Components\Documents\Document as DocumentComponent;
 use App\Utilities\Date;
+use App\Utilities\Documents as DocumentsUtilities;
 use App\Traits\Transactions;
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\DNSCheckValidation;
@@ -31,27 +32,12 @@ trait Documents
 
     public function getNextDocumentNumber(string $type): string
     {
-        if ($alias = config('type.document.' . $type . '.alias')) {
-            $type = $alias . '.' . str_replace('-', '_', $type);
-        }
-
-        $prefix = setting($type . '.number_prefix');
-        $next = setting($type . '.number_next');
-        $digit = setting($type . '.number_digit');
-
-        return $prefix . str_pad($next, $digit, '0', STR_PAD_LEFT);
+        return DocumentsUtilities::getNextDocumentNumber($type);
     }
 
     public function increaseNextDocumentNumber(string $type): void
     {
-        if ($alias = config('type.document.' . $type . '.alias')) {
-            $type = $alias . '.' . str_replace('-', '_', $type);
-        }
-
-        $next = setting($type . '.number_next', 1) + 1;
-
-        setting([$type . '.number_next' => $next]);
-        setting()->save();
+        DocumentsUtilities::increaseNextDocumentNumber($type);
     }
 
     public function getDocumentStatuses(string $type): Collection

--- a/app/Utilities/Documents.php
+++ b/app/Utilities/Documents.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Utilities;
+
+use Illuminate\Support\Traits\Macroable;
+
+/**
+ * Class Documents
+ *
+ * Contains macroable utility functions for documents.
+ *
+ * @package App\Utilities
+ */
+class Documents
+{
+    use Macroable;
+
+    public static function getNextDocumentNumber(string $type): string
+    {
+        if (static::hasMacro(__FUNCTION__)) {
+            return static::__callStatic(__FUNCTION__, [$type]);
+        }
+
+        if ($alias = config('type.document.' . $type . '.alias')) {
+            $type = $alias . '.' . str_replace('-', '_', $type);
+        }
+
+        $prefix = setting($type . '.number_prefix');
+        $next = setting($type . '.number_next');
+        $digit = setting($type . '.number_digit');
+
+        return $prefix . str_pad($next, $digit, '0', STR_PAD_LEFT);
+    }
+
+    public static function increaseNextDocumentNumber(string $type): void
+    {
+        if (static::hasMacro(__FUNCTION__)) {
+            static::__callStatic(__FUNCTION__, [$type]);
+            return;
+        }
+
+        if ($alias = config('type.document.' . $type . '.alias')) {
+            $type = $alias . '.' . str_replace('-', '_', $type);
+        }
+
+        $next = setting($type . '.number_next', 1) + 1;
+
+        setting([$type . '.number_next' => $next]);
+        setting()->save();
+    }
+}


### PR DESCRIPTION
This change allows modules to hook the document number generation functions through the Laravel 'Macroable' interface.

All changes are backwards compatible and do not change current behavior.