### PR TITLE
improve hooking capabilities when sending documents

### DIFF
--- a/app/Events/Document/DocumentSending.php
+++ b/app/Events/Document/DocumentSending.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events\Document;
+
+use App\Abstracts\Event;
+
+class DocumentSending extends Event
+{
+    public $document;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param $document
+     */
+    public function __construct($document)
+    {
+        $this->document = $document;
+    }
+}

--- a/app/Jobs/Document/SendDocument.php
+++ b/app/Jobs/Document/SendDocument.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Jobs\Document;
+
+use App\Abstracts\Job;
+use App\Events\Document\DocumentSending;
+use App\Events\Document\DocumentSent;
+use App\Models\Document\Document;
+
+class SendDocument extends Job
+{
+    public function __construct(Document $document)
+    {
+        $this->document = $document;
+    }
+
+    public function handle(): void
+    {
+        event(new DocumentSending($document));
+
+        // Notify the customer
+        $invoice->contact->notify(new Notification($invoice, 'invoice_new_customer', true));
+
+        event(new DocumentSent($document));
+    }
+}

--- a/app/Jobs/Document/SendDocumentAsCustomMail.php
+++ b/app/Jobs/Document/SendDocumentAsCustomMail.php
@@ -3,6 +3,7 @@
 namespace App\Jobs\Document;
 
 use App\Abstracts\Job;
+use App\Events\Document\DocumentSending;
 use App\Events\Document\DocumentSent;
 use App\Models\Document\Document;
 
@@ -17,6 +18,8 @@ class SendDocumentAsCustomMail extends Job
     public function handle(): void
     {
         $document = Document::find($this->request->get('document_id'));
+
+        event(new DocumentSending($document));
 
         $custom_mail = $this->request->only(['to', 'subject', 'body']);
 


### PR DESCRIPTION
* Adds a 'DocumentSending' event which is fired before the document is sent.
* Allows displaying an error message when sending fails.
* Is backwards compatible since the behavior of the 'DocumentSent' event did not change.