### PR TITLE
Log import errors

### DIFF
--- a/app/Utilities/Import.php
+++ b/app/Utilities/Import.php
@@ -51,6 +51,7 @@ class Import
                 'message'   => $message,
             ];
         } catch (Throwable $e) {
+            report($e);
             if ($e instanceof ValidationException) {
                 foreach ($e->failures() as $failure) {
                     $message = trans('messages.error.import_column', [


### PR DESCRIPTION
When importing if we have got any error, the error message is not descriptive for developers. We need to see the full error but the error is not logged into the log file. So with this PR, we are able to see the full trace in the log by using report helper. 
![log](https://user-images.githubusercontent.com/91991295/222816082-d18cdb88-ac2f-4bd7-85e7-038e95e669db.PNG)
