### PR TITLE
allow empty selection for tax form group component

### DIFF
--- a/app/View/Components/Form/Group/Tax.php
+++ b/app/View/Components/Form/Group/Tax.php
@@ -47,7 +47,7 @@ class Tax extends Form
             }
         }
 
-        if (empty($this->selected)) {
+        if (empty($this->selected) && empty($this->getParentData('model'))) {
             $this->selected = setting('default.tax');
         }
 


### PR DESCRIPTION
The component could not display an empty selection because it was always overwritten by the company's default setting.

Akaunting core does not use this form group.