### PR TITLE
Progress bar text color changed

### DIFF
--- a/public/css/element.css
+++ b/public/css/element.css
@@ -10202,7 +10202,7 @@
 }
 
 .el-progress-bar__innerText {
-    color: #FFF;
+    color: #FFF !important;
     font-size: 12px;
     margin: 0 5px
 }


### PR DESCRIPTION
before
<img width="266" alt="image" src="https://user-images.githubusercontent.com/107546467/225894373-4bee51b2-14da-49d1-8aff-62e8265a2ff7.png">
after
<img width="277" alt="image" src="https://user-images.githubusercontent.com/107546467/225894486-444cf005-f6bd-4ac9-8864-cd96cccb4dbb.png">
