### PR TITLE
add 'inline' route to allow embedding uploads

### DIFF
--- a/app/Http/Controllers/Common/Uploads.php
+++ b/app/Http/Controllers/Common/Uploads.php
@@ -34,6 +34,22 @@ class Uploads extends Controller
         return $this->streamMedia($media);
     }
 
+    public function inline($id)
+    {
+        try {
+            $media = Media::find($id);
+        } catch (\Exception $e) {
+            return response(null, 204);
+        }
+
+        // Get file path
+        if (!$this->getMediaPathOnStorage($media)) {
+            return response(null, 204);
+        }
+
+        return $this->streamMedia($media, 'inline');
+    }
+
     /**
      * Get the specified resource.
      *

--- a/app/Traits/Uploads.php
+++ b/app/Traits/Uploads.php
@@ -118,7 +118,7 @@ trait Uploads
         return $path;
     }
 
-    public function streamMedia($media)
+    public function streamMedia($media, $disposition = 'attachment')
     {
         return response()->streamDownload(
             function() use ($media) {
@@ -133,6 +133,7 @@ trait Uploads
                 'Content-Type'      => $media->mime_type,
                 'Content-Length'    => $media->size,
             ],
+            $disposition,
         );
     }
 

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Route;
  */
 
 Route::group(['as' => 'uploads.', 'prefix' => 'uploads'], function () {
+    Route::get('{id}/inline', 'Common\Uploads@inline')->name('inline');
     Route::delete('{id}', 'Common\Uploads@destroy')->name('destroy');
 });
 


### PR DESCRIPTION
This change adds an 'inline' route to uploads which sets the
'Content-Disposition' HTTP header to 'inline'. This allows modules to
embed and display uploads in an HTML 'embed' element.
