### PR TITLE
Add category object and category_id to document resource

### DIFF
--- a/app/Http/Resources/Document/Document.php
+++ b/app/Http/Resources/Document/Document.php
@@ -8,6 +8,7 @@ use App\Http\Resources\Document\DocumentHistory;
 use App\Http\Resources\Document\DocumentItem;
 use App\Http\Resources\Document\DocumentItemTax;
 use App\Http\Resources\Document\DocumentTotal;
+use App\Http\Resources\Setting\Category;
 use App\Http\Resources\Setting\Currency;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -32,6 +33,7 @@ class Document extends JsonResource
             'due_at' => $this->due_at ? $this->due_at->toIso8601String() : '',
             'amount' => $this->amount,
             'amount_formatted' => money($this->amount, $this->currency_code, true)->format(),
+            'category_id' => $this->category_id,
             'currency_code' => $this->currency_code,
             'currency_rate' => $this->currency_rate,
             'contact_id' => $this->contact_id,
@@ -50,6 +52,7 @@ class Document extends JsonResource
             'created_by' => $this->created_by,
             'created_at' => $this->created_at ? $this->created_at->toIso8601String() : '',
             'updated_at' => $this->updated_at ? $this->updated_at->toIso8601String() : '',
+            'category' => new Category($this->category),
             'currency' => new Currency($this->currency),
             'contact' => new Contact($this->contact),
             'histories' => [static::$wrap => DocumentHistory::collection($this->histories)],


### PR DESCRIPTION
The endpoint api/documents don't return the category of invoice/bill as the endpoint api/transactions do. With this change will be possible return this value.

The return after this change:

```json
{
	"data": [
		{
			"id": 3,
			...
			"category_id": 6,
			"category": {
				"id": 6,
				"company_id": 1,
				"name": "Category name",
				"type": "expense",
				"color": "green-500",
				"enabled": true,
				"parent_id": null,
				"created_from": "core::ui",
				"created_by": 1,
				"created_at": "2023-06-13T04:21:41+01:00",
				"updated_at": "2023-06-13T04:21:41+01:00"
			},
```