### PR TITLE
Using Prefix from ENV variable during installation

### DIFF
--- a/app/Http/Controllers/Install/Database.php
+++ b/app/Http/Controllers/Install/Database.php
@@ -34,9 +34,10 @@ class Database extends Controller
         $database = $request['database'];
         $username = $request['username'];
         $password = $request['password'];
+        $prefix   = config("database.connections.$connection.prefix", null);
 
         // Check database connection
-        if (!Installer::createDbTables($host, $port, $database, $username, $password)) {
+        if (!Installer::createDbTables($host, $port, $database, $username, $password, $prefix)) {
             $response = [
                 'status' => null,
                 'success' => false,


### PR DESCRIPTION
- Currently, during installation, we do not take into account the database table name prefix from env variables during installation (if specified by the user we ignore it and we try to generate a random prefix)
- For me putting that auto-generated random prefix back into environment variables failed after install, causing the installation to die, so I added it in env variables before hand, but that didn't help as we were ignoring it.