### PR TITLE
Add description when fetch document item

### DIFF
--- a/app/Http/Resources/Document/DocumentItem.php
+++ b/app/Http/Resources/Document/DocumentItem.php
@@ -22,6 +22,7 @@ class DocumentItem extends JsonResource
             'document_id' => $this->document_id,
             'item_id' => $this->item_id,
             'name' => $this->name,
+            'description' => $this->description,
             'price' => $this->price,
             'price_formatted' => money($this->price, $this->document->currency_code, true)->format(),
             'total' => $this->total,


### PR DESCRIPTION
The endpoint GET /api/documents/{id} return a list of items but the item haven't the description. With this update will return the description of a item.