### PR TITLE
Fixed missing default in settings match

### DIFF
--- a/app/Abstracts/Http/SettingController.php
+++ b/app/Abstracts/Http/SettingController.php
@@ -162,6 +162,7 @@ abstract class SettingController extends Controller
             'email.smtp_username'       => 'MAIL_USERNAME',
             'email.smtp_password'       => 'MAIL_PASSWORD',
             'email.smtp_encryption'     => 'MAIL_ENCRYPTION',
+            default                     => '',
         };
 
         if (empty($key)) {


### PR DESCRIPTION
Fixed bug where finding the env key for settings fails after last update's change from switch to match causing settings to be unchangeable 