### PR TITLE
Introduce csv as allowed file type in mediable config

### DIFF
--- a/config/mediable.php
+++ b/config/mediable.php
@@ -171,10 +171,12 @@ return [
             'mime_types' => [
                 'application/vnd.ms-excel',
                 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                'text/csv',
             ],
             'extensions' => [
                 'xls',
                 'xlsx',
+                'csv',
             ]
         ],
         Plank\Mediable\Media::TYPE_PRESENTATION => [


### PR DESCRIPTION
Discovered that should I want to allow uploading of csv files, simply adding the mime to the env var `FILESYSTEM_MIMES` will simply not be enough.

On top of the mimes passed to the form as validation, the `mediable` package also has a configuration.

This PR prepares the config for allowing users to add `csv,txt` to the mimes variables.