### PR TITLE
Fix request validation errors

### DIFF
--- a/app/Http/Requests/Auth/User.php
+++ b/app/Http/Requests/Auth/User.php
@@ -62,7 +62,7 @@ class User extends FormRequest
             $roles = 'required|string';
         }
 
-        $email .= '|unique:users,email,' . $id . ',id,deleted_at,NULL';
+        $email .= '|unique:users,email,' . ($id ?? 'null') . ',id,deleted_at,NULL';
 
         $change_password = $this->request->get('change_password') == true || $this->request->get('change_password') != null;
 

--- a/app/Http/Requests/Banking/Transaction.php
+++ b/app/Http/Requests/Banking/Transaction.php
@@ -39,7 +39,7 @@ class Transaction extends FormRequest
 
         $rules = [
             'type' => 'required|string',
-            'number' => 'required|string|unique:transactions,NULL,' . $id . ',id,company_id,' . $company_id . ',deleted_at,NULL',
+            'number' => 'required|string|unique:transactions,NULL,' . ($id ?? 'null') . ',id,company_id,' . $company_id . ',deleted_at,NULL',
             'account_id' => 'required|integer',
             'paid_at' => 'required|date_format:Y-m-d H:i:s',
             'amount' => 'required|amount:0',

--- a/app/Http/Requests/Document/Document.php
+++ b/app/Http/Requests/Document/Document.php
@@ -47,7 +47,7 @@ class Document extends FormRequest
 
         $rules = [
             'type'                  => 'required|string',
-            'document_number'       => 'required|string|unique:documents,NULL,' . $id . ',id,type,' . $type . ',company_id,' . $company_id . ',deleted_at,NULL',
+            'document_number'       => 'required|string|unique:documents,NULL,' . ($id ?? 'null') . ',id,type,' . $type . ',company_id,' . $company_id . ',deleted_at,NULL',
             //'status'                => 'required|string|in:draft,paid,partial,sent,received,viewed,cancelled',
             'status'                => 'required|string',
             'issued_at'             => 'required|date_format:Y-m-d H:i:s|before_or_equal:due_at',

--- a/app/Http/Requests/Setting/Currency.php
+++ b/app/Http/Requests/Setting/Currency.php
@@ -25,7 +25,7 @@ class Currency extends FormRequest
 
         return [
             'name' => 'required|string',
-            'code' => 'required|string|unique:currencies,NULL,' . $id . ',id,company_id,' . $company_id . ',deleted_at,NULL',
+            'code' => 'required|string|unique:currencies,NULL,' . ($id ?? 'null') . ',id,company_id,' . $company_id . ',deleted_at,NULL',
             'rate' => 'required|gt:0',
             'enabled' => 'integer|boolean',
             'default_currency' => 'nullable|boolean',

--- a/app/Http/Requests/Setting/Tax.php
+++ b/app/Http/Requests/Setting/Tax.php
@@ -27,7 +27,7 @@ class Tax extends FormRequest
         $type = 'required|string|in:fixed,normal,inclusive,withholding,compound';
 
         if (!empty($this->request->get('type')) && $this->request->get('type') == 'compound') {
-            $type .= '|unique:taxes,NULL,' . $id . ',id,company_id,' . $company_id . ',type,compound,deleted_at,NULL';
+            $type .= '|unique:taxes,NULL,' . ($id ?? 'null') . ',id,company_id,' . $company_id . ',type,compound,deleted_at,NULL';
         }
 
         return [


### PR DESCRIPTION
I'm using postgres 15.3 for the database, and when I create new entities I get this error on request validation:

```
"message": "SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type integer: \"\"\nCONTEXT:  unnamed portal parameter $2 = '' (Connection: pgsql, SQL: select count(*) as aggregate from \"kfo_currencies\" where \"code\" = AED and \"id\" <>  and \"company_id\" = 1 and \"deleted_at\" is null)",
    "exception": "Illuminate\\Database\\QueryException",
    "file": "/var/www/vendor/laravel/framework/src/Illuminate/Database/Connection.php",
    "line": 822,
```

the error being here: `and \"id\" <>  and \"company_id\" = 1` where instead of `NULL` it's passed as an empty string in the query.

@cuneytsenturk 