### PR TITLE
In Safari browser, the password shortcut appears above the password show/hide icon

### DIFF
--- a/resources/views/components/form/input/password.blade.php
+++ b/resources/views/components/form/input/password.blade.php
@@ -1,6 +1,7 @@
 <div x-data="{ showPassword: false, password: '' }" x-cloak>
     <input 
         type="password"
+        x-bind:class="password ? 'pr-9' : 'pr-0'"
         x-bind:type="showPassword ? 'text' : 'password'"
         x-model="password"
         name="{{ $name }}"


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/ed441942-8731-4f18-b1b8-0746c6a8c7de)

after
![image](https://github.com/user-attachments/assets/b3cc5414-c4cc-4f99-b8e2-3c7228020181)
