### PR TITLE
Fix deprecation warning in Notification.php by handling null values i…

### DIFF
--- a/app/Abstracts/Notification.php
+++ b/app/Abstracts/Notification.php
@@ -146,7 +146,8 @@ abstract class Notification extends BaseNotification implements ShouldQueue
         $new_vars = [];
 
         foreach ($vars as $var) {
-            $new_vars[] = preg_quote($var);
+            // Ensure $var is a string, default to an empty string if it is null
+            $new_vars[] = preg_quote($var ?? '');
         }
 
         return $new_vars;


### PR DESCRIPTION
Addressing Issue #3205 

Fix deprecation warning in Notification.php by handling null values in preg_quote()

**Description:**
Addressed a deprecation warning in `Notification.php` related to the `preg_quote()` function. The warning occurred because `preg_quote()` was being passed `null` values, which is deprecated in PHP 8.2. 

**Changes Made:**
- Updated the loop that processes the `$vars` array to ensure that each element passed to `preg_quote()` is a string. Added a default value of an empty string (`''`) when the element is `null`.

**Code Changes:**
```php
foreach ($vars as $var) {
    // Ensure $var is a string, default to an empty string if it is null
    $new_vars[] = preg_quote($var ?? '');
}