### PR TITLE
feat: add OpenLiteSpeed rewrite rule for protected files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -24,6 +24,10 @@
         </IfModule>
     </FilesMatch>
 
+    # Prevent Direct Access to Protected Files (OpenLiteSpeed syntax)
+    RewriteCond %{REQUEST_URI} (^|/)(\.env|\.log|artisan)$ [NC]
+    RewriteRule .* - [F,L]
+
     # Prevent Direct Access To Protected Folders
     RewriteRule ^(app|bootstrap|config|database|overrides|resources|routes|storage|tests)/(.*) / [L,R=301]
 


### PR DESCRIPTION
- Added a rewrite rule to block direct access to sensitive files (.env, .log, artisan) for OpenLiteSpeed environments.
- Retained the existing <FilesMatch> block for Apache compatibility.
- Ensures that both Apache and OpenLiteSpeed users have proper protection for protected files.