### PR TITLE
Recurring Invoices Break When Creating or Updating

### DIFF
--- a/app/Http/Controllers/Sales/RecurringInvoices.php
+++ b/app/Http/Controllers/Sales/RecurringInvoices.php
@@ -80,7 +80,9 @@ class RecurringInvoices extends Controller
      */
     public function store(Request $request)
     {
-        $response = $this->ajaxDispatch(new CreateDocument($request->merge(['issued_at' => $request->get('recurring_started_at')])));
+        $request->merge(['issued_at' => $request->get('recurring_started_at')]);
+
+        $response = $this->ajaxDispatch(new CreateDocument($request));
 
         if ($response['success']) {
             $response['redirect'] = route('recurring-invoices.show', $response['data']->id);
@@ -163,7 +165,9 @@ class RecurringInvoices extends Controller
      */
     public function update(Document $recurring_invoice, Request $request)
     {
-        $response = $this->ajaxDispatch(new UpdateDocument($recurring_invoice, $request->merge(['issued_at' => $request->get('recurring_started_at')])));
+        $request->merge(['issued_at' => $request->get('recurring_started_at')]);
+
+        $response = $this->ajaxDispatch(new UpdateDocument($recurring_invoice, $request));
 
         if ($response['success']) {
             $response['redirect'] = route('recurring-invoices.show', $response['data']->id);


### PR DESCRIPTION
Issue Resolved: 
- When creating or editing a recurring invoice, `RecurringInvoices::store()` and `RecurringInvoices::update()` dispatch `CreateDocument` / `UpdateDocument` jobs by calling `new CreateDocument($request->merge([...]))`.
- `FormRequest::merge()` mutates the request but returns `void`, so the expression ends up passing `null` into the job constructors.
- The job boot logic sees no request payload, builds an empty mock request, and the invoice gets created/updated without any of the validated fields (type, contact, items, schedule), leading to errors or corrupt data across the recurring invoices feature and any integrations that rely on it.

https://github.com/akaunting/akaunting/issues/3315