### PR TITLE
Fix missing non-recurring helpers in shared traits

### DIFF
--- a/app/Traits/Documents.php
+++ b/app/Traits/Documents.php
@@ -28,7 +28,7 @@ trait Documents
 
     public function isNotRecurringDocument(): bool
     {
-        return ! $this->isRecurring();
+        return ! $this->isRecurringDocument();
     }
 
     public function getRecurringDocumentTypes() : array

--- a/app/Traits/Transactions.php
+++ b/app/Traits/Transactions.php
@@ -42,7 +42,7 @@ trait Transactions
 
     public function isNotRecurringTransaction(): bool
     {
-        return ! $this->isRecurring();
+        return ! $this->isRecurringTransaction();
     }
 
     public function isTransferTransaction(): bool
@@ -194,7 +194,7 @@ trait Transactions
             'add_an' => trans('general.form.add_an', ['field' => trans_choice('general.' . Str::plural($document_type), 1)]),
             'transaction' => trans_choice('general.' . Str::plural($type), 1),
             'difference' => trans('general.difference'),
-            'connect_tax' => trans('messages.warning.connect_tax', ['type' => $type]), 
+            'connect_tax' => trans('messages.warning.connect_tax', ['type' => $type]),
         ];
     }
 


### PR DESCRIPTION
Enhancement Done:
- replace the `isNotRecurringDocument()` and `isNotRecurringTransaction()` guards to call their existing recurring helpers instead of the undefined `isRecurring()`.
- ensure every document/banking workflow can safely ask whether a record is non-recurring without triggering a fatal `BadMethodCallException`.
