### PR TITLE
Incorrect Return Type in Transaction::scopePaid() Method

### DIFF
--- a/app/Models/Banking/Transaction.php
+++ b/app/Models/Banking/Transaction.php
@@ -299,9 +299,9 @@ class Transaction extends Model
         return $query->orderBy('paid_at', 'desc');
     }
 
-    public function scopePaid(Builder $query): Builder
+    public function scopePaid(Builder $query): float
     {
-        return $query->whereNotNull('paid_at');
+        return $query->sum('amount');
     }
 
     public function scopeIsReconciled(Builder $query): Builder
@@ -571,7 +571,7 @@ class Transaction extends Model
         } catch (\Exception $e) {}
 
         try {
-            if (empty($this->document_id) 
+            if (empty($this->document_id)
                 && $this->isNotTransferTransaction()
                 && $this->isNotSplitTransaction()
             ) {


### PR DESCRIPTION
The `scopePaid()` method in the `Transaction` model has an incorrect implementation. It returns `$query->sum('amount')` which is a numeric value, but the method signature declares it should return a `Builder` instance. This violates the contract of Eloquent scope methods and will cause a type error when used.

**Current Code:**
```php
public function scopePaid(Builder $query): Builder
{
    return $query->sum('amount');
}
```

**Issue:**
- `sum('amount')` returns a numeric value (float/int), not a `Builder` instance
- This breaks the expected behavior of scope methods which should return a query builder for method chaining
