### PR TITLE
Fix Critical N+1 Query Performance Issues

### DIFF
--- a/app/Http/Controllers/Api/Document/Documents.php
+++ b/app/Http/Controllers/Api/Document/Documents.php
@@ -34,9 +34,33 @@ class Documents extends ApiController
     {
         // Check if we're querying by id or number
         if (is_numeric($id)) {
-            $document = Document::find($id);
+            $document = Document::with([
+                'contact',
+                'histories',
+                'items',
+                'items.taxes',
+                'items.taxes.tax',
+                'item_taxes',
+                'totals',
+                'transactions',
+                'transactions.currency',
+                'transactions.account',
+                'transactions.category',
+            ])->find($id);
         } else {
-            $document = Document::where('document_number', $id)->first();
+            $document = Document::with([
+                'contact',
+                'histories',
+                'items',
+                'items.taxes',
+                'items.taxes.tax',
+                'item_taxes',
+                'totals',
+                'transactions',
+                'transactions.currency',
+                'transactions.account',
+                'transactions.category',
+            ])->where('document_number', $id)->first();
         }
 
         if (! $document instanceof Document) {

--- a/app/Models/Document/Document.php
+++ b/app/Models/Document/Document.php
@@ -382,6 +382,11 @@ class Document extends Model
         $rate = $this->currency_rate;
         $precision = currency($code)->getPrecision();
 
+        // Lazy eager load transactions if not already loaded to prevent N+1 queries
+        if (!$this->relationLoaded('transactions')) {
+            $this->load('transactions');
+        }
+
         if ($this->transactions->count()) {
             foreach ($this->transactions as $transaction) {
                 $amount = $transaction->amount;
@@ -414,6 +419,11 @@ class Document extends Model
         $rate = $this->currency_rate;
         $precision = currency($code)->getPrecision();
 
+        // Lazy eager load transactions if not already loaded to prevent N+1 queries
+        if (!$this->relationLoaded('transactions')) {
+            $this->load('transactions');
+        }
+
         if ($this->transactions->count()) {
             foreach ($this->transactions as $transaction) {
                 $amount = $transaction->amount;
@@ -423,7 +433,7 @@ class Document extends Model
                 }
 
                 if ($transaction->reconciled) {
-                    $reconciled_amount = +$amount;
+                    $reconciled_amount += $amount;
                 }
             }
         }

--- a/app/Traits/Documents.php
+++ b/app/Traits/Documents.php
@@ -206,7 +206,8 @@ trait Documents
 
         $today = Date::today()->toDateString();
 
-        $documents = $documents ?: Document::type($type)->with('transactions')->future();
+        // Eager load transactions with currency to prevent N+1 queries when calling getAmountConvertedToDefault()
+        $documents = $documents ?: Document::type($type)->with(['transactions.currency'])->future();
 
         $documents->each(function ($document) use (&$totals, $today) {
             if (! in_array($document->status, $this->getDocumentStatusesForFuture())) {

--- a/app/View/Components/Contacts/Show/Content.php
+++ b/app/View/Components/Contacts/Show/Content.php
@@ -36,7 +36,8 @@ class Content extends Component
         // Handle documents
         $docs = $this->contact->isCustomer() ? 'invoices' : 'bills';
 
-        $this->documents = $this->contact->$docs()->with('transactions')->get();
+        // Eager load transactions with currency to prevent N+1 queries when calling getAmountConvertedToDefault()
+        $this->documents = $this->contact->$docs()->with(['transactions.currency'])->get();
 
         $this->counts['documents'] = $this->documents->count();
 
@@ -62,8 +63,8 @@ class Content extends Component
             }
         }
 
-        // Handle payments
-        $this->transactions = $this->contact->transactions()->with('account', 'category')->get();
+        // Handle payments - eager load currency to prevent N+1 queries
+        $this->transactions = $this->contact->transactions()->with(['account', 'category', 'currency'])->get();
 
         $this->counts['transactions'] = $this->transactions->count();
 

--- a/app/View/Components/Documents/Show/Attachment.php
+++ b/app/View/Components/Documents/Show/Attachment.php
@@ -17,6 +17,11 @@ class Attachment extends Component
     {
         $this->transaction_attachment = collect();
 
+        // Eager load transactions with their media/attachments to prevent N+1 queries
+        if (!$this->document->relationLoaded('transactions')) {
+            $this->document->load(['transactions.media', 'transactions']);
+        }
+
         if ($this->document->transactions->count()) {
             foreach ($this->document->transactions as $transaction) {
                 if (! $transaction->attachment) {


### PR DESCRIPTION
1. Document::getPaidAttribute() - Accessing transactions without eager loading
2. Document::getReconciledAttribute() - Accessing transactions without eager loading
3. View Component - Documents/Show/Attachment - Nested N+1 queries
4. Listeners - SendDocumentPaymentNotification - Accessing company users
5. API Endpoint - Documents::show() - Missing eager loading
6. Widget - ExpensesByCategory - Nested relationship access