### PR TITLE
Fix stored XSS in notification panel via contact/vendor name (CWE-79)

### DIFF
--- a/app/Abstracts/Notification.php
+++ b/app/Abstracts/Notification.php
@@ -135,7 +135,8 @@ abstract class Notification extends BaseNotification implements ShouldQueue
         foreach ($tags as $index => $tag) {
             $key = Str::replace($wrappers, '', $tag);
 
-            $bindings[$key] = $replacements[$index];
+            $value = $replacements[$index];
+            $bindings[$key] = is_string($value) ? e($value) : $value;
         }
 
         return $bindings;


### PR DESCRIPTION
## Security Fix — Stored Cross-Site Scripting (CWE-79)

### Summary
- User-supplied contact/vendor names are embedded into notification description strings without HTML escaping
- The notification blade template renders `data['description']` using `{!! !!}` (unescaped output)
- An attacker with `create-contacts` permission can store an XSS payload in a contact name that executes in every admin's browser when viewing the notification panel

### Root Cause

`getTagsBinding()` in `app/Abstracts/Notification.php` builds the translation parameter array used by `trans()` to fill notification description templates. The replacement values (customer name, vendor name, etc.) are stored as-is — no HTML escaping.

**Vulnerable code:**
```php
// app/Abstracts/Notification.php
foreach ($tags as $index => $tag) {
    $key = Str::replace($wrappers, '', $tag);
    $bindings[$key] = $replacements[$index];  // raw user value, no escaping
}
```

The resulting description is stored in the `notifications` table and rendered:
```blade
{{-- resources/views/livewire/menu/notifications.blade.php --}}
{!! $notification->data['description'] !!}  {{-- unescaped! --}}
```

### Fix

HTML-encode string replacement values in `getTagsBinding()` using Laravel's `e()` helper:

```php
foreach ($tags as $index => $tag) {
    $key = Str::replace($wrappers, '', $tag);
    $value = $replacements[$index];
    $bindings[$key] = is_string($value) ? e($value) : $value;
}
```

This preserves intentional HTML in the translation templates (`<strong>`, `<a>`) while safely encoding user-supplied values like `:customer_name`, `:vendor_name`.

### Attack Scenario

1. Attacker creates a contact with name: `<img src=x onerror=alert(document.cookie)>`
2. An invoice is sent to this contact; when the contact views the invoice via the portal signed URL, `DocumentViewed` event fires
3. Notification stored: `"<strong><img src=x onerror=alert(document.cookie)></strong> has viewed INV-0001..."`
4. Admin opens notification panel → XSS executes → session cookie stolen → account takeover

Also triggered by `invoice_payment_admin`, `invoice_recur_admin`, and `bill_recur_admin` notifications.

### Impact
- **Type**: CWE-79 — Stored Cross-Site Scripting
- **Auth required**: Yes (contact creation permission)
- **User interaction**: Admin must view the notification panel
- **Consequence**: JavaScript execution in admin context, session hijacking, privilege escalation

### Verification
Dynamically confirmed on v3.1.21 — XSS payload `<img src=x onerror=alert(document.cookie)>` rendered unescaped inside `<p class="text-black text-sm">` of the notification panel in the admin dashboard.