### PR TITLE
[codex] Fix pt-BR invoice bill_to translation

### DIFF
--- a/resources/lang/pt-BR/invoices.php
+++ b/resources/lang/pt-BR/invoices.php
@@ -8,7 +8,7 @@ return [
     'total_price'           => 'Valor total',
     'due_date'              => 'Data de Vencimento',
     'order_number'          => 'Número',
-    'bill_to'               => 'Pagar para',
+    'bill_to'               => 'Cobrar de',
     'cancel_date'           => 'Data de cancelamento',
 
     'quantity'              => 'Quantidade',


### PR DESCRIPTION
## What changed

Corrects the Brazilian Portuguese translation for the invoice `bill_to` label from `Pagar para` to `Cobrar de`.

## Why

On sales invoices, `bill_to` identifies who should be billed. The previous translation reads as "Pay to", which reverses the meaning and can confuse users issuing invoices.

## Validation

- `php -l resources/lang/pt-BR/invoices.php`
- `git diff --check upstream/master..HEAD`
