### PR TITLE
Fixed thousand-separator parsing for item sale/purchase price

### DIFF
--- a/app/Http/Middleware/Money.php
+++ b/app/Http/Middleware/Money.php
@@ -50,7 +50,7 @@ class Money
             if ($parameter == 'sale_price' || $parameter == 'purchase_price') {
                 $money_format = Str::replace(',', '.', $money_format);
 
-                if ($dot_count = Str::substrCount($money_format, '.') > 1) {
+                if (($dot_count = Str::substrCount($money_format, '.')) > 1) {
                     if ($dot_count > 2) {
                         $money_format = Str::replaceLast('.', '#', $money_format);
                         $money_format = Str::replace('.', '', $money_format);


### PR DESCRIPTION
The `Money` middleware normalizes localized `sale_price`/`purchase_price` input by replacing commas with dots and then collapsing the thousand separators, keeping only the last dot as the decimal mark. An operator-precedence mistake assigned the boolean result of the comparison to `$dot_count` instead of the separator count:

```php
if ($dot_count = Str::substrCount($money_format, '.') > 1)
```

Since `>` binds tighter than `=`, `$dot_count` was always `true`/`false`, and the inner `$dot_count > 2` branch — which handles values with three or more separators — was dead code. As a result prices such as `1.234.567,89` were truncated to `1234.567` when saved, the exact thousand-separator issue this code was added to fix (#1618). Wrapping the assignment in parentheses restores the intended count.

Verified before/after against the real middleware class: `1.234.567,89` → `1234567.89` and `12.345.678,90` → `12345678.9` now parse correctly, while the existing two-separator (`1.234,56`, `1,234.56`) and plain-number cases are unchanged.

_AI-assisted (Claude) and reviewed/verified before submitting._
