### PR TITLE
Fixed search string = operator returning an array instead of a string

### DIFF
--- a/app/Traits/SearchString.php
+++ b/app/Traits/SearchString.php
@@ -49,7 +49,12 @@ trait SearchString
 
             $extracted = trim($variable[1], '"\'');
 
-            if (str_contains($column, ':')) {
+            // ':' and '=' are single-value (exact match) operators, so return
+            // immediately. '>', '<', '>=' and '<=' are range operators that may
+            // repeat for the same column, so they fall through and accumulate.
+            $operator = substr($column, strlen($name));
+
+            if (str_starts_with($operator, ':') || str_starts_with($operator, '=')) {
                 return $extracted;
             }
 


### PR DESCRIPTION
`getSearchStringValue()` documents that both `:` and `=` are single-value (exact-match) operators returning a string, while `>` `<` `>=` `<=` are range operators that accumulate into an array. The early return only checked for `:`, so a `=` filter (e.g. `type=customer`, `account_id=5`) fell through and was returned as a one-element array.

This breaks callers expecting a string — e.g. `explode(',', $this->getSearchStringValue('account_id'))` in `app/Abstracts/Listeners/Report.php` throws a `TypeError` (HTTP 500) when a report is filtered with `account_id=5`.

**Fix**: detect the operator immediately after the column name so a leading `=` is matched while the `=` inside `>=`/`<=` is not, restoring the documented single-value behaviour for `=` without affecting range operators.

Verified on PHP 8.5 with a harness exercising the real trait: `type=customer` and `account_id=5` now return strings (previously arrays), the report `explode()` path no longer crashes, and `>`/`<`/`>=`/`<=` ranges still return arrays.

AI-assisted fix, reviewed and tested before submitting.
