### PR TITLE
Fixed database host and port not being applied to the current connection on install

### DIFF
--- a/app/Utilities/Installer.php
+++ b/app/Utilities/Installer.php
@@ -223,6 +223,9 @@ class Installer
         $db = Config::get('database.connections.' . $con);
 
         $db['host'] = $host;
+        $db['port'] = $port;
+        $db['read']['host'] = [$host];
+        $db['write']['host'] = [$host];
         $db['database'] = $database;
         $db['username'] = $username;
         $db['password'] = $password;


### PR DESCRIPTION
### Problem

Installing against a database on a non-default host or port fails during the migration, even though the installer has just accepted the same credentials:

```
Setting locale
Creating database tables
Connecting to database akaunting@127.0.0.1:3307

   Illuminate\Database\QueryException

  SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: YES)
  (Connection: mysql, SQL: select table_name as `name` ... from information_schema.tables ...)

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:829
  39  app/Utilities/Installer.php:161
```

The error message is misleading: the credentials are correct, and the database is reachable. The connection is simply not being made to the host and port that were given to the installer.

Running the installer a second time succeeds, because `.env` has been written in the meantime, so the correct values are read from the environment at boot. That makes the failure look intermittent.

### Cause

`Installer::saveDbVariables()` writes the values to `.env` and then updates the current connection, but the update does not reach the connection that is actually used:

- The `mysql` connection defines `read` and `write` host arrays (`config/database.php`), and those take precedence over the top level `host`. The existing `$db['host'] = $host;` line therefore has no effect on the connection.
- `port` is never assigned, so it keeps the value read from the environment at boot.

`isDbValid()` builds its own `install_test` connection with the given values, which is why validation passes immediately before the migration fails against a different host and port.

This affects any installation where the database is not on the host and port already present in `.env`: Docker, MAMP, cPanel, a secondary MySQL instance, or a remote server.

### Fix

Set `port` and the `read`/`write` hosts along with the values that were already being set.

### Steps to reproduce

1. Run a MySQL server on a non-default port, for example a Docker container published on `3307`
2. `cp .env.example .env`
3. `php artisan install --db-host=127.0.0.1 --db-port=3307 --db-name=akaunting --db-username=root --db-password=pass --admin-email=admin@company.com --admin-password=123456`

Before this change, the command exits with the error above and no tables are created. After it, the installation completes on the first run.

### Related

#3319 describes installing with a Docker MySQL container published on port `3307`, which is exactly the setup affected by this bug.
