### PR TITLE
Fix/3385 preserve submitted currency rate on payment update

### DIFF
--- a/app/Jobs/Banking/UpdateBankingDocumentTransaction.php
+++ b/app/Jobs/Banking/UpdateBankingDocumentTransaction.php
@@ -63,7 +63,7 @@ class UpdateBankingDocumentTransaction extends Job implements ShouldUpdate
         $this->request['company_id'] = $this->model->company_id;
         $this->request['currency_code'] = $currency_code;
         $this->request['paid_at'] = isset($this->request['paid_at']) ? $this->request['paid_at'] : Date::now()->toDateTimeString();
-        $this->request['currency_rate'] = currency($currency_code)->getRate();
+        $this->request['currency_rate'] = isset($this->request['currency_rate']) ? $this->request['currency_rate'] : currency($currency_code)->getRate();
         $this->request['account_id'] = isset($this->request['account_id']) ? $this->request['account_id'] : setting('default.account');
         $this->request['document_id'] = isset($this->request['document_id']) ? $this->request['document_id'] : $this->model->id;
         $this->request['contact_id'] = isset($this->request['contact_id']) ? $this->request['contact_id'] : $this->model->contact_id;

--- a/tests/Feature/Sales/InvoicesTest.php
+++ b/tests/Feature/Sales/InvoicesTest.php
@@ -15,6 +15,9 @@ use Illuminate\Support\Facades\Notification as NotificationFacade;
 use Illuminate\Support\Facades\Storage;
 use Maatwebsite\Excel\Facades\Excel;
 use Tests\Feature\FeatureTestCase;
+use App\Jobs\Banking\CreateBankingDocumentTransaction;
+use App\Jobs\Banking\UpdateBankingDocumentTransaction;
+use App\Models\Banking\Account;
 
 class InvoicesTest extends FeatureTestCase
 {
@@ -366,5 +369,39 @@ class InvoicesTest extends FeatureTestCase
             'subject'       => $notification->getSubject(),
             'body'          => $notification->getBody(),
         ];
+    }
+
+
+    public function testItShouldPreserveSubmittedCurrencyRateOnPaymentUpdate()
+    {
+        $this->loginAs();
+
+        $invoice = $this->dispatch(new CreateDocument($this->getRequest()));
+
+        $account = Account::first();
+
+        $payment = [
+            'account_id'     => $account->id,
+            'paid_at'        => Carbon::now()->toDateTimeString(),
+            'amount'         => 10,
+            'currency_code'  => $invoice->currency_code,
+            'currency_rate'  => 1.1628,
+            'payment_method' => setting('default.payment_method'),
+        ];
+
+        $transaction = $this->dispatch(
+            new CreateBankingDocumentTransaction($invoice, $payment)
+        );
+
+        $payment['amount'] = 11;
+
+        $transaction = $this->dispatch(
+            new UpdateBankingDocumentTransaction($invoice, $transaction, $payment)
+        );
+
+        $this->assertDatabaseHas('transactions', [
+            'id'            => $transaction->id,
+            'currency_rate' => 1.1628,
+        ]);
     }
 }


### PR DESCRIPTION
Fixes #3385 

UpdateBankingDocumentTransaction::prepareRequest() unconditionally overwrites the submitted currency_rate with the system rate, while CreateBankingDocumentTransaction only falls back when none was submitted.

Two effects:

checkAmount() converts with the wrong rate and throws a spurious over_payment error
If the amount passes that check, the transaction is saved with the wrong rate

Not API-only — Modals/DocumentTransactions.php:274 dispatches the same job, so the UI payment modal is affected on multi-currency documents.

Changed to match the create job. Added a regression test: without the fix, a submitted rate of 1.1628 is stored as 1.