### PR TITLE
Update docblocks left behind by the $job rename and route model binding

### DIFF
--- a/app/Http/Controllers/Auth/Users.php
+++ b/app/Http/Controllers/Auth/Users.php
@@ -418,7 +418,7 @@ class Users extends Controller
     /**
      * Process request for reinviting the specified resource.
      *
-     * @param  role_model_class()  $role
+     * @param  BaseRequest  $request
      *
      * @return Response
      */

--- a/app/Http/Controllers/Banking/Transfers.php
+++ b/app/Http/Controllers/Banking/Transfers.php
@@ -154,7 +154,7 @@ class Transfers extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  $id
+     * @param  Transfer  $transfer
      * @param  Request  $request
      *
      * @return Response
@@ -183,7 +183,7 @@ class Transfers extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  $id
+     * @param  Transfer  $transfer
      *
      * @return Response
      */

--- a/app/Http/Controllers/Install/Updates.php
+++ b/app/Http/Controllers/Install/Updates.php
@@ -305,8 +305,6 @@ class Updates extends Controller
     /**
      * Redirect back
      *
-     * @param  $request
-     *
      * @return Response
      */
     public function redirect()

--- a/app/Http/Controllers/Modals/DocumentItemColumns.php
+++ b/app/Http/Controllers/Modals/DocumentItemColumns.php
@@ -22,8 +22,6 @@ class DocumentItemColumns extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @param  Contact  $customer
-     *
      * @return Response
      */
     public function edit()

--- a/app/Http/Controllers/Modals/DocumentTransactions.php
+++ b/app/Http/Controllers/Modals/DocumentTransactions.php
@@ -263,8 +263,9 @@ class DocumentTransactions extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  $item
-     * @param  $request
+     * @param  Document  $document
+     * @param  Transaction  $transaction
+     * @param  Request  $request
      * @return Response
      */
     public function update(Document $document, Transaction $transaction, Request $request)

--- a/app/Http/Controllers/Portal/Profile.php
+++ b/app/Http/Controllers/Portal/Profile.php
@@ -35,7 +35,7 @@ class Profile extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  User $user
+     * @param  $user_id
      * @param  Request $request
      *
      * @return Response

--- a/app/Traits/Jobs.php
+++ b/app/Traits/Jobs.php
@@ -24,7 +24,7 @@ trait Jobs
     /**
      * Dispatch a job to its appropriate handler.
      *
-     * @param  mixed  $command
+     * @param  mixed  $job
      * @return mixed
      */
     public function dispatchQueue($job)
@@ -37,7 +37,7 @@ trait Jobs
      *
      * Queuable jobs will be dispatched to the "sync" queue.
      *
-     * @param  mixed  $command
+     * @param  mixed  $job
      * @param  mixed  $handler
      * @return mixed
      */


### PR DESCRIPTION
Most of these look like leftovers from renames. `Jobs` kept Laravel's `$command` after the argument became `$job`, while `dispatch` right above it already says `$job`. The two `Transfer` methods kept `$id` from before route model binding, and `edit` and `duplicate` in the same file are already updated. `landingPages` has a function call sitting where the type goes.
