### PR TITLE
Fix asset paths for artisan serve and installer database host/port

### DIFF
--- a/app/Utilities/Installer.php
+++ b/app/Utilities/Installer.php
@@ -223,6 +223,9 @@ class Installer
         $db = Config::get('database.connections.' . $con);
 
         $db['host'] = $host;
+        $db['port'] = $port;
+        $db['read']['host'][0] = $host;
+        $db['write']['host'][0] = $host;
         $db['database'] = $database;
         $db['username'] = $username;
         $db['password'] = $password;

--- a/resources/views/auth/forgot/create.blade.php
+++ b/resources/views/auth/forgot/create.blade.php
@@ -5,7 +5,7 @@
 
     <x-slot name="content">
         <div>
-            <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-16" alt="Akaunting" />
+            <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-16" alt="Akaunting" />
 
             <h1 class="text-lg my-3">
                 {{ trans('auth.reset_password') }}

--- a/resources/views/auth/login/create.blade.php
+++ b/resources/views/auth/login/create.blade.php
@@ -5,7 +5,7 @@
 
     <x-slot name="content">
         <div>
-            <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-16" alt="Akaunting" />
+            <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-16" alt="Akaunting" />
 
             <h1 class="text-lg my-3">
                 {{ trans('auth.login_to') }}

--- a/resources/views/auth/register/create.blade.php
+++ b/resources/views/auth/register/create.blade.php
@@ -5,7 +5,7 @@
 
     <x-slot name="content">
         <div>
-            <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-16" alt="Akaunting" />
+            <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-16" alt="Akaunting" />
 
             <h1 class="text-lg my-3">
                 {{ trans('auth.register_user') }}

--- a/resources/views/auth/reset/create.blade.php
+++ b/resources/views/auth/reset/create.blade.php
@@ -5,7 +5,7 @@
 
     <x-slot name="content">
         <div>
-            <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-16" alt="Akaunting" />
+            <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-16" alt="Akaunting" />
 
             <h1 class="text-lg my-3">
                 {{ trans('auth.reset_password') }}

--- a/resources/views/auth/users/index.blade.php
+++ b/resources/views/auth/users/index.blade.php
@@ -62,7 +62,7 @@
                                         @elseif (is_object($item->picture))
                                             <img src="{{ Storage::url($item->picture->id) }}" class="w-6 h-6 rounded-full ltr:mr-2 rtl:ml-2 hidden lg:block text-transparent" alt="{{ $item->name }}" title="{{ $item->name }}">
                                         @else
-                                            <img src="{{ asset('public/img/user.svg') }}" class="w-6 h-6 rounded-full ltr:mr-2 rtl:ml-2 hidden lg:block text-transparent" alt="{{ $item->name }}"/>
+                                            <img src="{{ asset('img/user.svg') }}" class="w-6 h-6 rounded-full ltr:mr-2 rtl:ml-2 hidden lg:block text-transparent" alt="{{ $item->name }}"/>
                                         @endif
 
                                         {{ !empty($item->name) ? $item->name : trans('general.na') }}

--- a/resources/views/auth/users/show.blade.php
+++ b/resources/views/auth/users/show.blade.php
@@ -61,7 +61,7 @@
                         @elseif (is_object($user->picture))
                             <img src="{{ Storage::url($user->picture->id) }}" class="absolute w-12 h-12 rounded-full hidden lg:block" alt="{{ $user->name }}" title="{{ $user->name }}">
                         @else
-                            <img src="{{ asset('public/img/user.svg') }}" class="absolute w-12 h-12 rounded-full hidden lg:block" alt="{{ $user->name }}"/>
+                            <img src="{{ asset('img/user.svg') }}" class="absolute w-12 h-12 rounded-full hidden lg:block" alt="{{ $user->name }}"/>
                         @endif
                     </x-slot>
 

--- a/resources/views/banking/recurring_transactions/show.blade.php
+++ b/resources/views/banking/recurring_transactions/show.blade.php
@@ -31,7 +31,7 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     <x-transactions.script type="{{ $recurring_transaction->type }}" folder="banking" file="transactions" />

--- a/resources/views/banking/transactions/import.blade.php
+++ b/resources/views/banking/transactions/import.blade.php
@@ -88,7 +88,7 @@
             <x-form id="import" :route="$form_params['route']" :url="$form_params['url']">
                 <div class="flex flex-col lg:flex-row">
                     <div class="hidden lg:flex w-4/12 ltr:-ml-10 rtl:-mr-10 ltr:mr-10 rtl:ml-10">
-                        <img src="{{ asset('public/img/import.png') }}" alt="{{ trans('import.title', ['type' => $title_type]) }}">
+                        <img src="{{ asset('img/import.png') }}" alt="{{ trans('import.title', ['type' => $title_type]) }}">
                     </div>
 
                     <!-- 

--- a/resources/views/banking/transactions/show.blade.php
+++ b/resources/views/banking/transactions/show.blade.php
@@ -16,7 +16,7 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     <x-transactions.script type="{{ $real_type }}" />

--- a/resources/views/banking/transfers/show.blade.php
+++ b/resources/views/banking/transfers/show.blade.php
@@ -51,7 +51,7 @@
     @endpush
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     <x-script folder="banking" file="transfers" />

--- a/resources/views/common/import/create.blade.php
+++ b/resources/views/common/import/create.blade.php
@@ -14,7 +14,7 @@
             <x-form id="import" :route="$form_params['route']" :url="$form_params['url']">
                 <div class="flex flex-col lg:flex-row">
                     <div class="hidden lg:flex w-4/12 ltr:-ml-10 rtl:-mr-10 ltr:mr-10 rtl:ml-10">
-                        <img src="{{ asset('public/img/import.png') }}" alt="{{ trans('import.title', ['type' => $title_type]) }}">
+                        <img src="{{ asset('img/import.png') }}" alt="{{ trans('import.title', ['type' => $title_type]) }}">
                     </div>
 
                     <!-- 

--- a/resources/views/components/contacts/index/content.blade.php
+++ b/resources/views/components/contacts/index/content.blade.php
@@ -140,7 +140,7 @@
                                     @if (is_object($item->logo))
                                         <img src="{{ Storage::url($item->logo->id) }}" class="absolute w-6 h-6 bottom-6 rounded-full ltr:mr-3 rtl:ml-3 hidden lg:block" alt="{{ $item->name }}" title="{{ $item->name }}">
                                     @else
-                                        <img src="{{ asset('public/img/user.svg') }}" class="absolute w-6 h-6 bottom-6 rounded-full ltr:mr-3 rtl:ml-3 hidden lg:block" alt="{{ $item->name }}"/>
+                                        <img src="{{ asset('img/user.svg') }}" class="absolute w-6 h-6 bottom-6 rounded-full ltr:mr-3 rtl:ml-3 hidden lg:block" alt="{{ $item->name }}"/>
                                     @endif
                                 @endif
 

--- a/resources/views/components/contacts/show/content.blade.php
+++ b/resources/views/components/contacts/show/content.blade.php
@@ -10,7 +10,7 @@
                         @if (is_object($contact->logo))
                             <img src="{{ Storage::url($contact->logo->id) }}" class="absolute w-12 h-12 rounded-full hidden lg:block" alt="{{ $contact->name }}" title="{{ $contact->name }}">
                         @else
-                            <img src="{{ asset('public/img/user.svg') }}" class="absolute w-12 h-12 rounded-full hidden lg:block" alt="{{ $contact->name }}"/>
+                            <img src="{{ asset('img/user.svg') }}" class="absolute w-12 h-12 rounded-full hidden lg:block" alt="{{ $contact->name }}"/>
                         @endif
 
                         {{ $contact->initials }}

--- a/resources/views/components/email/footer.blade.php
+++ b/resources/views/components/email/footer.blade.php
@@ -9,7 +9,7 @@
                                 <a href="{!! $url !!}" style="color: #676ba2; text-decoration: none;">{{ trans('footer.powered_by') }}&nbsp;</a>
                             </td>
                             <td align="center" valign="middle" style="text-align: center; padding-top: 5px;">
-                                <a href="{!! $url !!}"><img src="{{ asset('public/img/akaunting-logo-wild-blue.png') }}" style="height:20px;" alt="Akaunting" /></a>
+                                <a href="{!! $url !!}"><img src="{{ asset('img/akaunting-logo-wild-blue.png') }}" style="height:20px;" alt="Akaunting" /></a>
                             </td>
                         </tr>
                     </tbody>

--- a/resources/views/components/form/group/contact.blade.php
+++ b/resources/views/components/form/group/contact.blade.php
@@ -41,7 +41,7 @@
                                 :title="option.option.name"
                             >
                             <img v-else
-                                :src="'{{ url("/") }}' + '/public/img/user.svg'"
+                                :src="'{{ url("/") }}' + '/img/user.svg'"
                                 class="absolute w-12 h-12 rounded-full hidden lg:block"
                                 :alt="option.option.name"
                             />
@@ -96,7 +96,7 @@
                                 :title="option.option.name"
                             >
                             <img v-else
-                                :src="'{{ url("/") }}' + '/public/img/user.svg'"
+                                :src="'{{ url("/") }}' + '/img/user.svg'"
                                 class="absolute w-12 h-12 rounded-full hidden lg:block"
                                 :alt="option.option.name"
                             />
@@ -151,7 +151,7 @@
                                 :title="option.option.name"
                             >
                             <img v-else
-                                :src="'{{ url("/") }}' + '/public/img/user.svg'"
+                                :src="'{{ url("/") }}' + '/img/user.svg'"
                                 class="absolute w-12 h-12 rounded-full hidden lg:block"
                                 :alt="option.option.name"
                             />
@@ -203,7 +203,7 @@
                                 :title="option.option.name"
                             >
                             <img v-else
-                                :src="'{{ url("/") }}' + '/public/img/user.svg'"
+                                :src="'{{ url("/") }}' + '/img/user.svg'"
                                 class="absolute w-12 h-12 rounded-full hidden lg:block"
                                 :alt="option.option.name"
                             />

--- a/resources/views/components/layouts/admin/head.blade.php
+++ b/resources/views/components/layouts/admin/head.blade.php
@@ -16,22 +16,22 @@
 
     <x-layouts.pwa.head />
 
-    <link rel="stylesheet" href="{{ asset('public/css/custom_loading.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/custom_loading.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!--Icons-->
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
 
      <!-- Font -->
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/vue-html-editor.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/element.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/vue-html-editor.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/element.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/admin/menu.blade.php
+++ b/resources/views/components/layouts/admin/menu.blade.php
@@ -6,7 +6,7 @@
     <span class="material-icons text-black js-hamburger-menu">menu</span>
 
     <div class="flex items-center m-auto">
-        <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-8 m-auto" alt="Akaunting" />
+        <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-8 m-auto" alt="Akaunting" />
         <span class="ltr:ml-2 rtl:mr-2">{{ Str::limit(setting('company.name'), 22) }}</span>
     </div>
 
@@ -124,7 +124,7 @@
         <div class="relative mb-5 cursor-pointer">
             <button type="button" class="flex items-center" data-dropdown-toggle="dropdown-menu-company">
                 <div class="w-8 h-8 flex items-center justify-center">
-                    <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-6 h-6" alt="Akaunting" />
+                    <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-6 h-6" alt="Akaunting" />
                 </div>
 
                 <div class="flex ltr:ml-2 rtl:mr-2">

--- a/resources/views/components/layouts/admin/scripts.blade.php
+++ b/resources/views/components/layouts/admin/scripts.blade.php
@@ -1,5 +1,5 @@
 <!-- Core -->
-<script src="{{ asset('public/vendor/js-cookie/js.cookie.js') }}"></script>
+<script src="{{ asset('vendor/js-cookie/js.cookie.js') }}"></script>
 
 <script type="text/javascript">
     var company_currency_code = '{{ default_currency() }}';
@@ -11,9 +11,9 @@
 
 @stack('charts')
 
-<!-- <script type="text/javascript" src="{{ asset('public/akaunting-js/hotkeys.js') }}" defer></script> -->
-<script type="text/javascript" src="{{ asset('public/akaunting-js/generalAction.js') }}"></script>
-<script type="text/javascript" src="{{ asset('public/akaunting-js/popper.js') }}"></script>
+<!-- <script type="text/javascript" src="{{ asset('akaunting-js/hotkeys.js') }}" defer></script> -->
+<script type="text/javascript" src="{{ asset('akaunting-js/generalAction.js') }}"></script>
+<script type="text/javascript" src="{{ asset('akaunting-js/popper.js') }}"></script>
 
 <script type="text/javascript">
     "use strict";

--- a/resources/views/components/layouts/auth.blade.php
+++ b/resources/views/components/layouts/auth.blade.php
@@ -14,7 +14,7 @@
 
         @stack('body_start')
 
-        <div id="app" class="h-screen lg:h-auto bg-no-repeat bg-cover bg-center" style="background-image: url({{ asset('public/img/auth/login-bg.png') }});">
+        <div id="app" class="h-screen lg:h-auto bg-no-repeat bg-cover bg-center" style="background-image: url({{ asset('img/auth/login-bg.png') }});">
             <div class="relative w-full lg:max-w-7xl flex items-center m-auto">
                 <x-layouts.auth.slider>
                     {!! $slider ?? '' !!}

--- a/resources/views/components/layouts/auth/head.blade.php
+++ b/resources/views/components/layouts/auth/head.blade.php
@@ -16,20 +16,20 @@
 
     <x-layouts.pwa.head />
 
-    <link rel="stylesheet" href="{{ asset('public/css/custom_loading.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/custom_loading.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!--Icons-->
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
 
      <!-- Font -->
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/auth/scripts.blade.php
+++ b/resources/views/components/layouts/auth/scripts.blade.php
@@ -1,6 +1,6 @@
 @stack('scripts_start')
 
-<!-- <script type="text/javascript" src="{{ asset('public/akaunting-js/hotkeys.js') }}" defer></script> -->
+<!-- <script type="text/javascript" src="{{ asset('akaunting-js/hotkeys.js') }}" defer></script> -->
 
 @stack('body_css')
 

--- a/resources/views/components/layouts/auth/slider.blade.php
+++ b/resources/views/components/layouts/auth/slider.blade.php
@@ -5,7 +5,7 @@
             <div class="swiper-wrapper">
                 <div class="swiper-slide flex justify-center flex-col items-center">
                     <div style="width:450px; height:450px;">
-                        <img src="{{ asset('public/img/auth/folder.png') }}" alt="{{ trans('auth.information.invoice') }}" />
+                        <img src="{{ asset('img/auth/folder.png') }}" alt="{{ trans('auth.information.invoice') }}" />
                     </div>
 
                     <h1 class="text-3xl text-black-400 font-bold">
@@ -15,7 +15,7 @@
 
                 <div class="swiper-slide flex justify-center flex-col items-center">
                     <div style="width:450px; height:450px;">
-                        <img src="{{ asset('public/img/auth/chart.png') }}" alt="{{ trans('auth.information.reports') }}" />
+                        <img src="{{ asset('img/auth/chart.png') }}" alt="{{ trans('auth.information.reports') }}" />
                     </div>
 
                     <h1 class="text-3xl text-black-400 font-bold">
@@ -25,7 +25,7 @@
 
                 <div class="swiper-slide flex justify-center flex-col items-center">
                     <div style="width:450px; height:450px;">
-                        <img src="{{ asset('public/img/auth/client.png') }}" alt="{{ trans('auth.information.expense') }}" />
+                        <img src="{{ asset('img/auth/client.png') }}" alt="{{ trans('auth.information.expense') }}" />
                     </div>
 
                     <h1 class="text-3xl text-black-400 font-bold">
@@ -35,7 +35,7 @@
 
                 <div class="swiper-slide flex justify-center flex-col items-center">
                     <div style="width:450px; height:450px;">
-                        <img src="{{ asset('public/img/auth/layout.png') }}" alt="{{ trans('general.dashboard') }}" />
+                        <img src="{{ asset('img/auth/layout.png') }}" alt="{{ trans('general.dashboard') }}" />
                     </div>
 
                     <h1 class="text-3xl text-black-400 font-bold">

--- a/resources/views/components/layouts/error/head.blade.php
+++ b/resources/views/components/layouts/error/head.blade.php
@@ -17,18 +17,18 @@
     <x-layouts.pwa.head />
 
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!--Icons-->
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
 
      <!-- Font -->
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/element.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/element.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/install.blade.php
+++ b/resources/views/components/layouts/install.blade.php
@@ -9,16 +9,16 @@
     <body>
         @stack('body_start')
 
-        <div class="h-screen lg:h-auto bg-no-repeat bg-cover bg-center" style="background-image: url({{ asset('public/img/auth/login-bg.png') }});">
+        <div class="h-screen lg:h-auto bg-no-repeat bg-cover bg-center" style="background-image: url({{ asset('img/auth/login-bg.png') }});">
             @if (! file_exists(public_path('js/install.min.js')))
                 <div class="relative w-full lg:max-w-7xl flex flex-col lg:flex-row items-center m-auto">
                     <div class="md:w-6/12 h-screen hidden lg:flex flex-col items-center justify-center">
-                        <img src="{{ asset('public/img/empty_pages/transactions.png') }}" alt="Akaunting Installation" />
+                        <img src="{{ asset('img/empty_pages/transactions.png') }}" alt="Akaunting Installation" />
                     </div>
 
                     <div class="w-full lg:w-46 h-31 flex flex-col justify-center gap-12 px-6 lg:px-24 py-24 mt-12 lg:mt-0">
                         <div class="flex flex-col gap-4">
-                            <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-16 my-3" alt="Akaunting" />
+                            <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-16 my-3" alt="Akaunting" />
 
                             <div class="rounded-xl px-5 py-3 mb-5 bg-red-100 text-sm mb-0 text-red-600">
                                 {!! trans('install.requirements.npm') !!}
@@ -34,7 +34,7 @@
 
                     <div class="w-full lg:w-46 h-31 flex flex-col justify-center gap-12 px-6 lg:px-24 py-24 mt-12 lg:mt-0">
                         <div class="flex flex-col gap-4">
-                            <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-16 my-3" alt="Akaunting" />
+                            <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-16 my-3" alt="Akaunting" />
 
                             <x-layouts.install.content :title="$title">
                                 {!! $content !!}

--- a/resources/views/components/layouts/install/head.blade.php
+++ b/resources/views/components/layouts/install/head.blade.php
@@ -17,18 +17,18 @@
     <x-layouts.pwa.head />
 
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!--Icons-->
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
 
      <!-- Font -->
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/element.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/element.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/install/scripts.blade.php
+++ b/resources/views/components/layouts/install/scripts.blade.php
@@ -1,6 +1,6 @@
 @stack('scripts_start')
 
-<script src="{{ asset('public/js/install.min.js?v=' . version('short')) }}"></script>
+<script src="{{ asset('js/install.min.js?v=' . version('short')) }}"></script>
 
 @stack('body_css')
 

--- a/resources/views/components/layouts/maintenance/body.blade.php
+++ b/resources/views/components/layouts/maintenance/body.blade.php
@@ -8,7 +8,7 @@
             </span>
         </div>
 
-        <img src="{{ asset('public/img/empty_pages/transactions.png') }}" alt="{{ trans('maintenance.message') }}" />
+        <img src="{{ asset('img/empty_pages/transactions.png') }}" alt="{{ trans('maintenance.message') }}" />
     </div>
 
     @stack('body_end')

--- a/resources/views/components/layouts/maintenance/head.blade.php
+++ b/resources/views/components/layouts/maintenance/head.blade.php
@@ -11,9 +11,9 @@
 
     <base href="{{ config('app.url') . '/' }}">
 
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/modules/head.blade.php
+++ b/resources/views/components/layouts/modules/head.blade.php
@@ -16,22 +16,22 @@
 
     <x-layouts.pwa.head />
 
-    <link rel="stylesheet" href="{{ asset('public/css/custom_loading.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/custom_loading.css?v=' . version('short')) }}" type="text/css">
     
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!--Icons-->
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
 
      <!-- Font -->
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/vue-html-editor.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/element.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/vue-html-editor.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/element.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/portal/head.blade.php
+++ b/resources/views/components/layouts/portal/head.blade.php
@@ -16,21 +16,21 @@
 
     <x-layouts.pwa.head />
 
-    <link rel="stylesheet" href="{{ asset('public/css/custom_loading.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/custom_loading.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!--Icons-->
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
 
      <!-- Font -->
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/element.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/element.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/portal/menu.blade.php
+++ b/resources/views/components/layouts/portal/menu.blade.php
@@ -6,7 +6,7 @@
     <span class="material-icons text-black js-hamburger-menu">menu</span>
 
     <div class="flex items-center m-auto">
-        <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-8 m-auto" alt="Akaunting" />
+        <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-8 m-auto" alt="Akaunting" />
         <span class="ltr:ml-2 rtl:mr-2">{{ Str::limit(setting('company.name'), 22) }}</span>
     </div>
 </div>
@@ -91,7 +91,7 @@
         <div class="relative mb-5 cursor-pointer">
             <button type="button" class="flex items-center" data-dropdown-toggle="dropdown-menu-company">
                 <div class="w-8 h-8 flex items-center justify-center">
-                    <img src="{{ asset('public/img/akaunting-logo-green.svg') }}" class="w-6 h-6" alt="Akaunting" />
+                    <img src="{{ asset('img/akaunting-logo-green.svg') }}" class="w-6 h-6" alt="Akaunting" />
                 </div>
 
                 <div class="flex ltr:ml-2 rtl:mr-2">

--- a/resources/views/components/layouts/portal/scripts.blade.php
+++ b/resources/views/components/layouts/portal/scripts.blade.php
@@ -1,5 +1,5 @@
 <!-- Core -->
-<script src="{{ asset('public/vendor/js-cookie/js.cookie.js') }}"></script>
+<script src="{{ asset('vendor/js-cookie/js.cookie.js') }}"></script>
 
 <script type="text/javascript">
     var company_currency_code = '{{ default_currency() }}';
@@ -11,9 +11,9 @@
 
 @stack('charts')
 
-<!-- <script type="text/javascript" src="{{ asset('public/akaunting-js/hotkeys.js') }}" defer></script> -->
-<script type="text/javascript" src="{{ asset('public/akaunting-js/generalAction.js') }}"></script>
-<script type="text/javascript" src="{{ asset('public/akaunting-js/popper.js') }}"></script>
+<!-- <script type="text/javascript" src="{{ asset('akaunting-js/hotkeys.js') }}" defer></script> -->
+<script type="text/javascript" src="{{ asset('akaunting-js/generalAction.js') }}"></script>
+<script type="text/javascript" src="{{ asset('akaunting-js/popper.js') }}"></script>
 
 <script type="text/javascript">
     "use strict";

--- a/resources/views/components/layouts/preview/head.blade.php
+++ b/resources/views/components/layouts/preview/head.blade.php
@@ -16,21 +16,21 @@
 
     <x-layouts.pwa.head />
 
-    <link rel="stylesheet" href="{{ asset('public/css/custom_loading.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/custom_loading.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!--Icons-->
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
 
      <!-- Font -->
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/element.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/element.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/print/head.blade.php
+++ b/resources/views/components/layouts/print/head.blade.php
@@ -15,17 +15,17 @@
     <base href="{{ config('app.url') . '/' }}">
 
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css/print.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/print.css') }}" type="text/css">
 
     @if (isset($currency_style) && $currency_style || in_array(app()->getLocale(), ['zh-CN', 'ja-JP', 'zh-TW']))
     <style type="text/css">
         @font-face {
             font-family: 'Firefly Sung';
             font-weight: 'normal';
-            src: url('{{ asset("/public/css/fonts/firefly_sung_normal.ttf") }}') format("truetype");
+            src: url('{{ asset("css/fonts/firefly_sung_normal.ttf") }}') format("truetype");
         }
 
         * {
@@ -37,7 +37,7 @@
         @font-face {
             font-family: 'Noto Sans Arabic';
             font-weight: normal;
-            src: url('{{ asset("/public/css/fonts/NotoSansArabic.ttf") }}') format("truetype");
+            src: url('{{ asset("css/fonts/NotoSansArabic.ttf") }}') format("truetype");
         }
 
         * {

--- a/resources/views/components/layouts/print/scripts.blade.php
+++ b/resources/views/components/layouts/print/scripts.blade.php
@@ -1,5 +1,5 @@
 <!-- Core -->
-<script src="{{ asset('public/vendor/js-cookie/js.cookie.js') }}"></script>
+<script src="{{ asset('vendor/js-cookie/js.cookie.js') }}"></script>
 
 <script type="text/javascript">
     var company_currency_code = '{{ default_currency() }}';

--- a/resources/views/components/layouts/pwa/head.blade.php
+++ b/resources/views/components/layouts/pwa/head.blade.php
@@ -7,27 +7,27 @@
 <!-- Add to homescreen for Chrome on Android -->
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="application-name" content="{{ config('app.name') }}">
-<link rel="icon" sizes="512x512" href="{{ asset('public/img/pwa/icon-512x512.png') }}">
+<link rel="icon" sizes="512x512" href="{{ asset('img/pwa/icon-512x512.png') }}">
 
 <!-- Add to homescreen for Safari on iOS -->
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="#ffffff">
 <meta name="apple-mobile-web-app-title" content="{{ config('app.name') }}">
-<link rel="apple-touch-icon" href="{{ asset('public/img/pwa/icon-512x512.png') }}">
+<link rel="apple-touch-icon" href="{{ asset('img/pwa/icon-512x512.png') }}">
 
-<link href="{{ asset('public/img/pwa/splash-640x1136.png') }}" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-750x1334.png') }}" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-828x1792.png') }}" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1242x2208.png') }}" media="(device-width: 621px) and (device-height: 1104px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1242x2688.png') }}" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1536x2048.png') }}" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1668x2224.png') }}" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-1668x2388.png') }}" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
-<link href="{{ asset('public/img/pwa/splash-2048x2732.png') }}" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-640x1136.png') }}" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-750x1334.png') }}" media="(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-828x1792.png') }}" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1242x2208.png') }}" media="(device-width: 621px) and (device-height: 1104px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1242x2688.png') }}" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1536x2048.png') }}" media="(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1668x2224.png') }}" media="(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-1668x2388.png') }}" media="(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
+<link href="{{ asset('img/pwa/splash-2048x2732.png') }}" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2)" rel="apple-touch-startup-image" />
 
 <!-- Tile for Win8 -->
 <meta name="msapplication-TileColor" content="#ffffff">
-<meta name="msapplication-TileImage" content="{{ asset('public/img/pwa/icon-512x512.png') }}">
+<meta name="msapplication-TileImage" content="{{ asset('img/pwa/icon-512x512.png') }}">
 
 <script type="text/javascript">
     if ('serviceWorker' in navigator) {

--- a/resources/views/components/layouts/signed/head.blade.php
+++ b/resources/views/components/layouts/signed/head.blade.php
@@ -16,21 +16,21 @@
 
     <x-layouts.pwa.head />
 
-    <link rel="stylesheet" href="{{ asset('public/css/custom_loading.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/custom_loading.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!--Icons-->
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
 
      <!-- Font -->
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css//third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/element.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/third_party/swiper-bundle.min.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/element.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/wizard/background.blade.php
+++ b/resources/views/components/layouts/wizard/background.blade.php
@@ -1,2 +1,2 @@
 <div class="w-full h-full absolute inset-0 bg-cover bg-no-repeat opacity-20"
-    style="background-image:url({{ asset('public/img/dashboard.png') }});"></div>
+    style="background-image:url({{ asset('img/dashboard.png') }});"></div>

--- a/resources/views/components/layouts/wizard/head.blade.php
+++ b/resources/views/components/layouts/wizard/head.blade.php
@@ -15,17 +15,17 @@
     <base href="{{ config('app.url') . '/' }}">
 
     <!-- Favicon -->
-    <link rel="icon" href="{{ asset('public/img/favicon.ico') }}" type="image/png">
+    <link rel="icon" href="{{ asset('img/favicon.ico') }}" type="image/png">
 
     <!--Icons-->
-    <link rel="stylesheet" href="{{ asset('public/css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/fonts/material-icons/style.css?v=' . version('short')) }}" type="text/css">
 
      <!-- Font -->
-    <link rel="stylesheet" href="{{ asset('public/vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('vendor/quicksand/css/quicksand.css?v=' . version('short')) }}" type="text/css">
 
     <!-- Css -->
-    <link rel="stylesheet" href="{{ asset('public/css/element.css?v=' . version('short')) }}" type="text/css">
-    <link rel="stylesheet" href="{{ asset('public/css/app.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/element.css?v=' . version('short')) }}" type="text/css">
+    <link rel="stylesheet" href="{{ asset('css/app.css?v=' . version('short')) }}" type="text/css">
 
     @stack('css')
 

--- a/resources/views/components/layouts/wizard/scripts.blade.php
+++ b/resources/views/components/layouts/wizard/scripts.blade.php
@@ -1,9 +1,9 @@
 @stack('scripts_start')
 
 <!-- Core -->
-<script src="{{ asset('public/vendor/js-cookie/js.cookie.js') }}"></script>
-<script type="text/javascript" src="{{ asset('public/akaunting-js/generalAction.js') }}"></script>
-<script type="text/javascript" src="{{ asset('public/akaunting-js/popper.js') }}"></script>
+<script src="{{ asset('vendor/js-cookie/js.cookie.js') }}"></script>
+<script type="text/javascript" src="{{ asset('akaunting-js/generalAction.js') }}"></script>
+<script type="text/javascript" src="{{ asset('akaunting-js/popper.js') }}"></script>
 
 <script type="text/javascript">
     var wizard_translations = {!! json_encode($translations) !!};
@@ -14,7 +14,7 @@
     var wizard_modules = {!! json_encode($modules) !!};
 </script>
 
-<script src="{{ asset('public/js/wizard/wizard.min.js?v=' . version('short')) }}"></script>
+<script src="{{ asset('js/wizard/wizard.min.js?v=' . version('short')) }}"></script>
 
 @stack('body_css')
 

--- a/resources/views/components/loading/absolute.blade.php
+++ b/resources/views/components/loading/absolute.blade.php
@@ -13,6 +13,6 @@
     class="absolute w-full lg:flex items-start justify-center bg-body top-0 bottom-0 left-0 right-0 z-50"
     style="z-index: 60;"
 >
-    <img src="{{ asset('public/img/akaunting-loading.gif') }}" class="w-40 h-40" alt="Akaunting" />
+    <img src="{{ asset('img/akaunting-loading.gif') }}" class="w-40 h-40" alt="Akaunting" />
 </div>
 <!--data attr added because for none vue.js pages-->

--- a/resources/views/components/loading/content.blade.php
+++ b/resources/views/components/loading/content.blade.php
@@ -13,6 +13,6 @@
     class="fixed w-full lg:w-4/5 h-screen flex items-center justify-center bg-body top-0 bottom-0 ltr:right-0 rtl:left-0 -mx-1 z-50"
     style="z-index: 60;"
 >
-    <img src="{{ asset('public/img/akaunting-loading.gif') }}" class="w-40 h-40 lg:-mt-16" alt="Akaunting" />
+    <img src="{{ asset('img/akaunting-loading.gif') }}" class="w-40 h-40 lg:-mt-16" alt="Akaunting" />
 </div>
 <!--data attr added because for none vue.js pages-->

--- a/resources/views/components/modules/banners.blade.php
+++ b/resources/views/components/modules/banners.blade.php
@@ -29,7 +29,7 @@
         </div>
 
         <div class="hidden lg:block">
-            <img src="{{ asset('/public/img/akaunting-logo-gold.png') }}" class="h-40" alt="Akaunting" />
+            <img src="{{ asset('img/akaunting-logo-gold.png') }}" class="h-40" alt="Akaunting" />
         </div>
     </div>
 @endif

--- a/resources/views/components/modules/no_apps.blade.php
+++ b/resources/views/components/modules/no_apps.blade.php
@@ -1,6 +1,6 @@
 <div class="flex flex-col gap-6 mb-8">
     <div class="relative w-full mb-36 lg:mb-0">
-        <img src="{{ asset('public/img/empty_pages/no-apps.png') }}" class="w-full" alt="{{ trans('modules.no_apps_marketing') }}" />
+        <img src="{{ asset('img/empty_pages/no-apps.png') }}" class="w-full" alt="{{ trans('modules.no_apps_marketing') }}" />
 
         <div class="absolute inset-0 flex flex-col top-1/4 items-center gap-4">
             <h1 class="text-xl lg:text-5xl text-center text-black font-semibold">

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -30,7 +30,7 @@
                 </x-link>
             </div>
 
-            <img src="{{ asset('public/img/errors/403.png') }}" alt="403" />
+            <img src="{{ asset('img/errors/403.png') }}" alt="403" />
         </div>
     </x-slot>
 </x-layouts.error>

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -30,7 +30,7 @@
                 </x-link>
             </div>
 
-            <img src="{{ asset('public/img/errors/404.png') }}" alt="404" />
+            <img src="{{ asset('img/errors/404.png') }}" alt="404" />
         </div>
     </x-slot>
 </x-layouts.error>

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -30,7 +30,7 @@
                 </x-link>
             </div>
 
-            <img src="{{ asset('public/img/errors/500.png') }}" alt="500" />
+            <img src="{{ asset('img/errors/500.png') }}" alt="500" />
         </div>
     </x-slot>
 </x-layouts.error>

--- a/resources/views/modals/settings/transfer_template.blade.php
+++ b/resources/views/modals/settings/transfer_template.blade.php
@@ -3,7 +3,7 @@
         <div class="grid sm:grid-cols-6 gap-x-8 gap-y-6 my-3.5">
             <div class="sm:col-span-2 bg-gray-100 rounded-lg cursor-pointer text-center py-2 px-2">
                 <div @click="transfer_form.template='default'">
-                    <img src="{{ asset('public/img/transfer_templates/default.png') }}" class="h-72 m-auto" alt="Default"/>
+                    <img src="{{ asset('img/transfer_templates/default.png') }}" class="h-72 m-auto" alt="Default"/>
                     </br>
                     <label style="font-size: initial;">
                         <input type="radio" name="template" value="default" v-model="transfer_form.template">
@@ -14,7 +14,7 @@
 
             <div class="sm:col-span-2 bg-gray-100 rounded-lg cursor-pointer text-center py-2 px-2">
                 <div @click="transfer_form.template='second'">
-                    <img src="{{ asset('public/img/transfer_templates/second.png') }}" class="h-72 m-auto" alt="Second"/>
+                    <img src="{{ asset('img/transfer_templates/second.png') }}" class="h-72 m-auto" alt="Second"/>
                     </br>
                     <label style="font-size: initial;">
                         <input type="radio" name="template" value="second" v-model="transfer_form.template">
@@ -25,7 +25,7 @@
 
             <div class="sm:col-span-2 bg-gray-100 rounded-lg cursor-pointer text-center py-2 px-2">
                 <div @click="transfer_form.template='third'">
-                    <img src="{{ asset('public/img/transfer_templates/third.png') }}" class="h-72 m-auto" alt="Third"/>
+                    <img src="{{ asset('img/transfer_templates/third.png') }}" class="h-72 m-auto" alt="Third"/>
                     </br>
                     <label style="font-size: initial;">
                         <input type="radio" name="template" value="third" v-model="transfer_form.template">

--- a/resources/views/portal/invoices/preview.blade.php
+++ b/resources/views/portal/invoices/preview.blade.php
@@ -140,7 +140,7 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     @push('scripts_start')

--- a/resources/views/portal/invoices/show.blade.php
+++ b/resources/views/portal/invoices/show.blade.php
@@ -138,7 +138,7 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     <x-script folder="portal" file="apps" />

--- a/resources/views/portal/invoices/signed.blade.php
+++ b/resources/views/portal/invoices/signed.blade.php
@@ -147,7 +147,7 @@
         </x-slot>
 
         @push('stylesheet')
-            <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+            <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
         @endpush
 
         @push('scripts_start')

--- a/resources/views/portal/payments/preview.blade.php
+++ b/resources/views/portal/payments/preview.blade.php
@@ -64,7 +64,7 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     <x-script folder="portal" file="apps" />

--- a/resources/views/portal/payments/show.blade.php
+++ b/resources/views/portal/payments/show.blade.php
@@ -63,6 +63,6 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 </x-layouts.portal>

--- a/resources/views/portal/payments/signed.blade.php
+++ b/resources/views/portal/payments/signed.blade.php
@@ -71,7 +71,7 @@
         </x-slot>
 
         @push('stylesheet')
-            <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+            <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
         @endpush
 
         <x-script folder="portal" file="apps" />

--- a/resources/views/purchases/bills/show.blade.php
+++ b/resources/views/purchases/bills/show.blade.php
@@ -38,7 +38,7 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     <x-documents.script type="bill" :document="$bill" />

--- a/resources/views/purchases/recurring_bills/show.blade.php
+++ b/resources/views/purchases/recurring_bills/show.blade.php
@@ -33,7 +33,7 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     <x-documents.script type="bill-recurring" />

--- a/resources/views/sales/invoices/show.blade.php
+++ b/resources/views/sales/invoices/show.blade.php
@@ -20,7 +20,7 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     <x-documents.script type="invoice" :document="$invoice" />

--- a/resources/views/sales/recurring_invoices/show.blade.php
+++ b/resources/views/sales/recurring_invoices/show.blade.php
@@ -33,7 +33,7 @@
     </x-slot>
 
     @push('stylesheet')
-        <link rel="stylesheet" href="{{ asset('public/css/print.css?v=' . version('short')) }}" type="text/css">
+        <link rel="stylesheet" href="{{ asset('css/print.css?v=' . version('short')) }}" type="text/css">
     @endpush
 
     <x-documents.script type="invoice-recurring" />

--- a/resources/views/settings/invoice/edit.blade.php
+++ b/resources/views/settings/invoice/edit.blade.php
@@ -31,7 +31,7 @@
                         <div class="sm:col-span-2 rounded-lg cursor-pointer text-center py-2 px-2">
                             <label class="cursor-pointer">
                                 <div @click="form.template='default'" class="flex flex-col items-center">
-                                    <img src="{{ asset('public/img/invoice_templates/default.png') }}" class="h-60 my-3" alt="Default" />
+                                    <img src="{{ asset('img/invoice_templates/default.png') }}" class="h-60 my-3" alt="Default" />
 
                                     <div class="flex items-center space-x-2 rtl:space-x-reverse">
                                         <input type="radio" name="template" value="default" v-model="form._template">
@@ -44,7 +44,7 @@
                         <div class="sm:col-span-2 rounded-lg cursor-pointer text-center py-2 px-2">
                             <label class="cursor-pointer">
                                 <div @click="form.template='classic'" class="flex flex-col items-center">
-                                    <img src="{{ asset('public/img/invoice_templates/classic.png') }}" class="h-60 my-3" alt="Classic" />
+                                    <img src="{{ asset('img/invoice_templates/classic.png') }}" class="h-60 my-3" alt="Classic" />
 
                                     <div class="flex items-center space-x-2 rtl:space-x-reverse">
                                         <input type="radio" name="template" value="classic" v-model="form._template">
@@ -57,7 +57,7 @@
                         <div class="sm:col-span-2 rounded-lg cursor-pointer text-center py-2 px-2">
                             <label class="cursor-pointer">
                                 <div @click="form.template='modern'" class="flex flex-col items-center">
-                                    <img src="{{ asset('public/img/invoice_templates/modern.png') }}" class="h-60 my-3" alt="Modern" />
+                                    <img src="{{ asset('img/invoice_templates/modern.png') }}" class="h-60 my-3" alt="Modern" />
 
                                     <div class="flex items-center space-x-2 rtl:space-x-reverse">
                                         <input type="radio" name="template" value="modern" v-model="form._template">

--- a/tests/Feature/AssetLoadingTest.php
+++ b/tests/Feature/AssetLoadingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class AssetLoadingTest extends TestCase
+{
+    public function test_blade_assets_do_not_use_public_prefix()
+    {
+        $viewsPath = resource_path('views');
+        $filesWithPublicPrefix = [];
+
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($viewsPath));
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                $content = file_get_contents($file->getPathname());
+                if (preg_match("/asset\(\s*['\"]\/?public\//", $content)) {
+                    $filesWithPublicPrefix[] = str_replace(base_path() . '/', '', $file->getPathname());
+                }
+            }
+        }
+
+        $this->assertEmpty(
+            $filesWithPublicPrefix,
+            "Found blade files using asset('public/...') which breaks php artisan serve (document root is public/):\n" . implode("\n", $filesWithPublicPrefix)
+        );
+    }
+
+    public function test_no_double_slash_in_asset_paths()
+    {
+        $viewsPath = resource_path('views');
+        $filesWithDoubleSlash = [];
+
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($viewsPath));
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                $content = file_get_contents($file->getPathname());
+                if (strpos($content, "asset('public/css//") !== false || strpos($content, 'asset("public/css//') !== false) {
+                    $filesWithDoubleSlash[] = str_replace(base_path() . '/', '', $file->getPathname());
+                }
+            }
+        }
+
+        $this->assertEmpty($filesWithDoubleSlash, "Found asset paths with double slash: " . implode(", ", $filesWithDoubleSlash));
+    }
+}

--- a/tests/Feature/InstallerDbConfigTest.php
+++ b/tests/Feature/InstallerDbConfigTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Utilities\Installer;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class InstallerDbConfigTest extends TestCase
+{
+    public function test_save_db_variables_sets_port_and_read_write_hosts()
+    {
+        // Setup: ensure we have a mysql connection config with read/write hosts
+        Config::set('database.default', 'mysql');
+        Config::set('database.connections.mysql', [
+            'driver' => 'mysql',
+            'read' => ['host' => ['127.0.0.1']],
+            'write' => ['host' => ['127.0.0.1']],
+            'port' => '3306',
+            'host' => '127.0.0.1',
+            'database' => 'forge',
+            'username' => 'forge',
+            'password' => '',
+            'prefix' => 'ak_',
+        ]);
+
+        // Create a dummy .env to avoid file errors
+        $envPath = base_path('.env');
+        $envBackup = null;
+        if (is_file($envPath)) {
+            $envBackup = file_get_contents($envPath);
+        } else {
+            file_put_contents($envPath, "APP_KEY=base64:test\nDB_HOST=127.0.0.1\nDB_PORT=3306\n");
+        }
+
+        Installer::saveDbVariables('192.168.1.50', '3307', 'akaunting', 'root', 'pass', 'ak_');
+
+        $db = Config::get('database.connections.mysql');
+
+        // Restore .env
+        if ($envBackup !== null) {
+            file_put_contents($envPath, $envBackup);
+        } else {
+            @unlink($envPath);
+        }
+
+        $this->assertEquals('192.168.1.50', $db['host'], 'host should be updated');
+        $this->assertEquals('3307', $db['port'], 'port should be updated to custom port 3307');
+        $this->assertEquals('192.168.1.50', $db['read']['host'][0], 'read host should be updated for Docker/non-default host');
+        $this->assertEquals('192.168.1.50', $db['write']['host'][0], 'write host should be updated');
+        $this->assertEquals('akaunting', $db['database']);
+    }
+}


### PR DESCRIPTION
Fixes #3319

`php artisan serve` uses `public/` as document root, but Blade templates generated asset URLs with a `public/` prefix that 404 and the installer left the database port and read/write hosts unchanged so Docker installs on non-default ports failed. Removed the redundant `public/` prefix from asset URLs and made the installer apply the supplied port and hosts to the active connection.