### PR TITLE
Replace deprecated node-sass with dart-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "css-loader": "^6.7.3",
         "laravel-mix": "^6.0.49",
         "mini-css-extract-plugin": "^2.7.5",
-        "node-sass": "^9.0.0",
+        "sass": "^1.77.0",
         "postcss": "^8.4.32",
         "postcss-import": "^15.1.0",
         "postcss-loader": "^7.2.4",


### PR DESCRIPTION
### Problem

`node-sass` is deprecated (LibSass was sunset by the Sass team) and its native addon no longer builds against current Node releases, so `npm install` fails before any assets can be compiled:

```
gyp ERR! cwd node_modules/node-sass
gyp ERR! node -v v24.19.0
gyp ERR! node-gyp -v v8.4.1
gyp ERR! not ok
npm error Build failed with error code: 1
```

Reproduced on a clean checkout of `master` with Node 24 and `node-sass@9.0.0`. This blocks the documented install steps (`composer install ; npm install ; npm run dev`) on any modern Node version.

### Change

Swaps `node-sass` for `sass` (dart-sass), the maintained reference implementation and the one `sass-loader` already expects. It is pure JavaScript, so there is no native compilation step and installs work regardless of Node version.

One line in `package.json`; `sass-loader` is unchanged.

### Why this is low risk

The build does not actually compile any Sass:

- `webpack.mix.js` builds CSS through `.postCss()` with Tailwind and never calls `.sass()`
- the only `.scss` file in the tree, `resources/assets/css/creditcard/style.scss`, is not referenced by the build

So this removes a broken dependency without changing any stylesheet output.

### Verification

With this `package.json`, `npm install` completes and `npm run prod` compiles successfully — all JS bundles and `css/app.css` are produced, and the emitted CSS is unchanged.
