### PR TITLE
Remove two array keys that a later duplicate already overrides

### DIFF
--- a/app/Http/Controllers/Modals/DocumentTransactions.php
+++ b/app/Http/Controllers/Modals/DocumentTransactions.php
@@ -113,7 +113,6 @@ class DocumentTransactions extends Controller
             ],
             'payment' => [
                 'text' => trans('invoices.accept_payments'),
-                'class' => 'long-texts',
                 'before_text' => trans('general.get_paid_faster'),
                 'class' => 'px-6 py-1.5 text-xs bg-gray-200 hover:bg-purple-200 font-medium rounded-lg leading-6 long-texts',
                 'url' => route('apps.categories.show', [

--- a/app/Listeners/Update/V30/Version300.php
+++ b/app/Listeners/Update/V30/Version300.php
@@ -377,7 +377,6 @@ class Version300 extends Listener
             'purchases-payments' => 'c,r,u,d',
             'sales-revenues' => 'c,r,u,d',
             'settings-settings' => 'r,u',
-            'settings-settings' => 'r,u',
             'widgets-income-by-category' => 'r',
             'widgets-latest-expenses' => 'r',
             'widgets-latest-income' => 'r',


### PR DESCRIPTION
Two arrays set the same key twice. In `DocumentTransactions` the `payment` button has `'class' => 'long-texts'` and then `'class' => 'px-6 py-1.5 ... long-texts'` three lines later, and in `Version300` the permissions map lists `'settings-settings' => 'r,u'` on two consecutive lines. PHP keeps the last value, so the first `class` has never reached the button and the second permission line has never added anything.

Removed the losing line in each case, so nothing renders or seeds differently than it does today. The long class list already ends with `long-texts`, so the button keeps every class it has now.
