### PR TITLE
fix: apply currency conversion when company currency matches account …

### DIFF
--- a/app/Traits/Currencies.php
+++ b/app/Traits/Currencies.php
@@ -48,7 +48,11 @@ trait Currencies
             $default_amount = $this->convertToDefault($amount, $from_code, $from_rate);
         }
 
-        $converted_amount = $this->convertFromDefault($default_amount, $to_code, $to_rate);
+        if ($to_code != default_currency()) {
+            $converted_amount = $this->convertFromDefault($default_amount, $to_code, $to_rate);
+        } else {
+            $converted_amount = $default_amount;
+        }
 
         return $converted_amount;
     }

--- a/resources/assets/js/views/common/documents.js
+++ b/resources/assets/js/views/common/documents.js
@@ -281,7 +281,12 @@ const app = new Vue({
                 default_amount = this.convertToDefault(amount, from_code, from_rate, false, null);
             }
 
-            let converted_amount = this.convertFromDefault(default_amount, to_code, to_rate, false, null);
+            let converted_amount;
+            if (to_code != this.form.company_currency_code) {
+                converted_amount = this.convertFromDefault(default_amount, to_code, to_rate, false, null);
+            } else {
+                converted_amount = default_amount;
+            }
 
             return converted_amount;
         },


### PR DESCRIPTION
Fixes #3384

## Problem

Currency conversion is skipped when the company's default currency matches the target currency in `convertBetween()`.

**Example from the issue:**
- Company currency: **USD**, Invoice: **GBP (£253)**, Payment: **USD**
- Expected: conversion applied → correct converted amount recorded
- Actual: conversion skipped → raw invoice amount recorded as-is

## Root Cause

`convertBetween()` converts amounts via a two-step pipeline through the company's default currency:

```
from_code → [Step 1: ÷ from_rate] → default_currency → [Step 2: × to_rate] → to_code
```

Step 1 has a guard — skip if `from_code == default_currency()` (amount is already in the default currency). But Step 2 unconditionally calls `convertFromDefault()` → `convert()`, which has its own short-circuit:

```php
if ($from == $to) {
    return $money->getAmount(); // Returns unchanged
}
```

When `to_code` equals the default currency, `convert()` sees `$from == $to` and returns the amount without applying the rate. The function is asymmetric: Step 1 is guarded but Step 2 is not.

## Fix

Added a symmetric guard for Step 2 in both **PHP** and **JavaScript** `convertBetween()`:

**PHP — `app/Traits/Currencies.php`:**
```diff
  if ($from_code != default_currency()) {
      $default_amount = $this->convertToDefault($amount, $from_code, $from_rate);
  }

- $converted_amount = $this->convertFromDefault($default_amount, $to_code, $to_rate);
+ if ($to_code != default_currency()) {
+     $converted_amount = $this->convertFromDefault($default_amount, $to_code, $to_rate);
+ } else {
+     $converted_amount = $default_amount;
+ }
```

**JavaScript — `resources/assets/js/views/common/documents.js`:**
```diff
  if (from_code != this.form.company_currency_code) {
      default_amount = this.convertToDefault(amount, from_code, from_rate, false, null);
  }

- let converted_amount = this.convertFromDefault(default_amount, to_code, to_rate, false, null);
+ let converted_amount;
+ if (to_code != this.form.company_currency_code) {
+     converted_amount = this.convertFromDefault(default_amount, to_code, to_rate, false, null);
+ } else {
+     converted_amount = default_amount;
+ }
```

When `to_code` IS the default currency, the amount after Step 1 is already correct — no further conversion needed. This makes the function logically symmetric and prevents the `convert()` short-circuit from silently dropping conversions.

## Impact

All call sites that use `convertBetween()` benefit from this fix automatically:
- `CreateBankingDocumentTransaction::checkAmount()`
- `UpdateBankingDocumentTransaction::checkAmount()`
- `Document::getPaidAttribute()`
- `Document::getReconciledAttribute()`
- `Transaction::getAmountForAccountAttribute()`
- `Transaction::getAmountForDocumentAttribute()`
- Frontend payment modal amount calculations
