### PR TITLE
fix: include plain-value columns in search string token validation (#…

### DIFF
--- a/app/Traits/SearchString.php
+++ b/app/Traits/SearchString.php
@@ -143,6 +143,7 @@ trait SearchString
 
         $valid_columns = array_unique(array_merge(
             array_keys($model_config_columns),
+            array_values(array_filter($model_config_columns, 'is_string')),
             array_values(config('search-string.default.keywords', [])),
             array_keys(config('search-string.default.columns', [])),
         ));


### PR DESCRIPTION
Fixes #3383

## Problem

REST API search filters like `search=number:"txn_1"` silently return **all results** instead of filtering, because `stripUnknownSearchStringTokens()` (introduced in commit 7825f872c) incorrectly strips valid column tokens from the search string.

## Root Cause

In `stripUnknownSearchStringTokens()`, the valid columns list is built using `array_keys()` on the model's columns config:

```php
$valid_columns = array_unique(array_merge(
    array_keys($model_config_columns),   // ← BUG
    ...
));
```

But in `config/search-string.php`, columns are defined in a **mixed PHP array** — some with config arrays (string keys), some as plain values (numeric keys):

```php
'columns' => [
    'id',              // key=0, value='id'      ← plain value
    'number',          // key=1, value='number'   ← plain value
    'type' => [...],   // key='type'              ← string key
    'amount',          // key=2, value='amount'   ← plain value
]
```

`array_keys()` returns `[0, 1, 'type', 'account_id', ...]` — the **numeric indices**, not the column names. So `'number'`, `'id'`, `'amount'`, etc. are missing from the valid columns list and get stripped as "unknown tokens".

After stripping, the search string becomes empty → `usingSearchString('')` → the config's `'fail' => 'all-results'` kicks in → all records are returned.

## Fix

**1 line added** to also collect plain string values from the columns config:

```diff
 $valid_columns = array_unique(array_merge(
     array_keys($model_config_columns),
+    array_values(array_filter($model_config_columns, 'is_string')),
     array_values(config('search-string.default.keywords', [])),
     array_keys(config('search-string.default.columns', [])),
 ));
```

`array_filter($model_config_columns, 'is_string')` keeps only the plain string entries (filtering out sub-arrays), then `array_values()` extracts the column names.

## Affected Models

Every model with plain-value columns in `config/search-string.php` is affected:

| Model | Affected Columns |
|-------|-----------------|
| `Banking\Transaction` | `id`, `number`, `amount`, `document_id`, `payment_method`, `reference`, `parent_id` |
| `Banking\Transfer` | `id` |
| `Banking\Account` | `id` |
| `Common\Company` | `id` |
| `Common\Item` | `id`, `sale_price`, `purchase_price` |
| `Common\Contact` | `id`, `type`, `reference`, `user_id` |
| `Document\Document` | `id`, `amount`, `contact_tax_number`, `parent_id` |
| `Sale\Invoice` | `id`, `amount`, `contact_tax_number`, `parent_id` |
| `Purchase\Bill` | `id`, `amount`, `contact_tax_number`, `parent_id` |
| `Setting\Currency` | `id`, `precision`, `symbol`, `decimal_mark`, `thousands_separator` |
| `Setting\Tax` | `id`, `rate` |
| `Portal\Sale\Invoice` | `id`, `amount`, `parent_id` |
| `Portal\Banking\Transaction` | `id`, `amount`, `document_id`, `payment_method`, `reference`, `parent_id` |
